### PR TITLE
Bump proj-relman/generic-worker-ubuntu-22-04 worker's max capacity to 50

### DIFF
--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -51,7 +51,7 @@ relman:
       imageset: generic-worker-ubuntu-22-04
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 5
+      maxCapacity: 50
       workerConfig:
         genericWorker:
           config:


### PR DESCRIPTION
We are using it in place of 'ci' in code-coverage and code-review, and 'ci' had 50 as max capacity.