### PR TITLE
Disable SysMain (Superfetch) to improve performance

### DIFF
--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -29,6 +29,9 @@ Set-ExecutionPolicy Unrestricted -Force -Scope Process
 # TestAbortAfterMaxRunTime from running as intended.
 Uninstall-WindowsFeature -Name Windows-Defender
 
+# Disable SysMain (Superfetch)
+Set-Service "SysMain" -StartupType Disabled -Status Stopped
+
 # Disable disk indexing
 Set-Service "WSearch" -StartupType Disabled -Status Stopped
 


### PR DESCRIPTION
This service is meant to improve performance over time. In the short term it consumes compute resources. This is not helpful for fuzzing and likely any other use case.