### PR TITLE
Added `queue:route:checks` to relman projects

### DIFF
--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -89,6 +89,7 @@ relman:
     - grant:
         - queue:create-task:highest:proj-relman/*
         - queue:route:statuses
+        - queue:route:checks
       to:
         - repo:github.com/mozilla/microannotate:*
         - repo:github.com/mozilla/task-boot:*


### PR DESCRIPTION
Forgot to add after switching code-coverage, code-review repos to us checks api