### PR TITLE
Fix pipelines

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -32,7 +32,6 @@ tasks:
             - '-c'
             - >-
               git clone ${repo.clone_url} repo &&
-              echo "this is test" &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
@@ -71,7 +70,7 @@ tasks:
           $map: {$eval: tests}
           each(test):
             taskId: {$eval: as_slugid(test.name)}
-            provisionerId: proj-misc
+            provisionerId: proj-taskcluster
             workerType: ci
             created: {$fromNow: ''}
             deadline: {$fromNow: '60 minutes'}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -32,6 +32,7 @@ tasks:
             - '-c'
             - >-
               git clone ${repo.clone_url} repo &&
+              echo "this is test" &&
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&

--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -106,7 +106,7 @@ fuzzing:
       emailOnError: true
       bindings:
         - exchange: exchange/taskcluster-github/v1/push
-          routingKeyPattern: primary.mozilla.community-tc-config
+          routingKeyPattern: primary.taskcluster.community-tc-config
       task:
         provisionerId: proj-fuzzing
         workerType: ci


### PR DESCRIPTION
Updated .taskcluster.yml provisioner to allow `proj-taskcluster/ci` workers to pick up tasks (instead of `proj-misc/ci`)

Updates community-tc-config hook after migration