### PR TITLE
chore: add binary locations to win2016 worker config

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -174,6 +174,8 @@ generic-worker-win2016-amd:
     genericWorker:
       config:
         ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
+        livelogExecutable: C:\generic-worker\livelog.exe
+        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
         shutdownMachineOnIdle: true
         idleTimeoutSecs: 15
         shutdownMachineOnInternalError: true


### PR DESCRIPTION
@tysmith @jschwartzentruber please confirm this updated config works and we'll get this landed. The config has already been applied.

Fixes https://github.com/taskcluster/community-tc-config/issues/695.