### PR TITLE
Install Linux extra modules and configure vKMS for all cloud providers

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -133,13 +133,13 @@ generic-worker-ubuntu-22-04-staging:
         workerTypeMetadata:
           machine-setup:
             maintainer: taskcluster-notifications+workers@mozilla.com
-            script: https://github.com/taskcluster/community-tc-config/blob/9bda57bb9486efcc6b9807e042cc3ab28045dd97/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
+            script: https://github.com/taskcluster/community-tc-config/blob/9d26f3c5f9cd4c514c44f8889a3f0215e17ebd8a/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
   aws:
     amis:
-      us-west-1: ami-0eae38b3abb754b59
-      us-west-2: ami-062c42a6bc6f84712
-      us-east-1: ami-0de7c16ad4f8444a3
-      us-east-2: ami-0a77f93044c8644f3
+      us-west-1: ami-0c033fb53eb3e272e
+      us-west-2: ami-0b5b08e6448cc8f74
+      us-east-1: ami-0fcf17451a885d4ca
+      us-east-2: ami-0885c3b3c05364ef5
   gcp:
     image: projects/community-tc-workers/global/images/generic-worker-ubuntu-22-04-staging-nr31k8jqg6rmc8l8486c
 generic-worker-win2022:

--- a/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04-staging/bootstrap.sh
@@ -126,17 +126,15 @@ retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman
   echo 'registries=["docker.io"]'
 ) >> /etc/containers/registries.conf
 
-if [[ "%MY_CLOUD%" == "google" ]]; then
-    # Installs the v4l2loopback kernel module
-    # used for the video device, and vkms
-    # required by Wayland in GCP.
-    retry apt-get install -y linux-modules-extra-$(uname -r)
-    # needed for mutter to work with DRM rather than falling back to X11
-    grep -Fx vkms /etc/modules || echo vkms >> /etc/modules
-    # disable udev rule that tags platform-vkms with "mutter-device-ignore"
-    # ENV{ID_PATH}=="platform-vkms", TAG+="mutter-device-ignore"
-    sed '/platform-vkms/d' /lib/udev/rules.d/61-mutter.rules > /etc/udev/rules.d/61-mutter.rules
-fi
+# Installs the v4l2loopback kernel module
+# used for the video device, and vkms
+# required by Wayland
+retry apt-get install -y linux-modules-extra-$(uname -r)
+# needed for mutter to work with DRM rather than falling back to X11
+grep -Fx vkms /etc/modules || echo vkms >> /etc/modules
+# disable udev rule that tags platform-vkms with "mutter-device-ignore"
+# ENV{ID_PATH}=="platform-vkms", TAG+="mutter-device-ignore"
+sed '/platform-vkms/d' /lib/udev/rules.d/61-mutter.rules > /etc/udev/rules.d/61-mutter.rules
 
 # install necessary packages for KVM
 # https://help.ubuntu.com/community/KVM/Installation

--- a/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-22-04/bootstrap.sh
@@ -117,17 +117,15 @@ retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman
   echo 'registries=["docker.io"]'
 ) >> /etc/containers/registries.conf
 
-if [[ "%MY_CLOUD%" == "google" ]]; then
-    # Installs the v4l2loopback kernel module
-    # used for the video device, and vkms
-    # required by Wayland in GCP.
-    retry apt-get install -y linux-modules-extra-$(uname -r)
-    # needed for mutter to work with DRM rather than falling back to X11
-    grep -Fx vkms /etc/modules || echo vkms >> /etc/modules
-    # disable udev rule that tags platform-vkms with "mutter-device-ignore"
-    # ENV{ID_PATH}=="platform-vkms", TAG+="mutter-device-ignore"
-    sed '/platform-vkms/d' /lib/udev/rules.d/61-mutter.rules > /etc/udev/rules.d/61-mutter.rules
-fi
+# Installs the v4l2loopback kernel module
+# used for the video device, and vkms
+# required by Wayland
+retry apt-get install -y linux-modules-extra-$(uname -r)
+# needed for mutter to work with DRM rather than falling back to X11
+grep -Fx vkms /etc/modules || echo vkms >> /etc/modules
+# disable udev rule that tags platform-vkms with "mutter-device-ignore"
+# ENV{ID_PATH}=="platform-vkms", TAG+="mutter-device-ignore"
+sed '/platform-vkms/d' /lib/udev/rules.d/61-mutter.rules > /etc/udev/rules.d/61-mutter.rules
 
 # See
 #   * https://console.aws.amazon.com/support/cases#/6410417131/en


### PR DESCRIPTION
Until now we've only configured vKMS on Linux workers if they are running GCP, not in other clouds.
Testing AWS staging Ubuntu using the same technique as used with GCP in #709 in this PR.

Currently AWS staging [is using](https://community-tc.services.mozilla.com/tasks/WRw6TLQwT1-bHycctYV7Aw/runs/0/logs/public/logs/live.log#L34) an X11 graphical backend rather than DRM.