### PR TITLE
Temporarily disable shutdowns after panic in proj-taskcluster/gw-ubuntu-22-04

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -99,6 +99,7 @@ taskcluster:
         genericWorker:
           config:
             enableInteractive: true
+            shutdownMachineOnInternalError: false
 
     gw-ubuntu-22-04-arm64:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
Currently getting a lot of errors in https://community-tc.services.mozilla.com/worker-manager/proj-taskcluster%2Fgw-ubuntu-22-04/errors

Hopefully with this setting, workers will stay alive long enough for us to grab logs or execute commands on them to see what is wrong. Then we can disable afterwards.