### PR TITLE
Increase max capacity of proj-misc/tutorial

### DIFF
--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -23,6 +23,9 @@ misc:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 50
+      genericWorker:
+        config:
+          idleTimeoutSecs: 600
   hooks:
     jcristau-fx-release-metrics:
       description: Taskcluster hook to run fx release metrics

--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -22,7 +22,7 @@ misc:
       imageset: generic-worker-ubuntu-22-04
       cloud: gcp
       minCapacity: 0
-      maxCapacity: 2
+      maxCapacity: 50
   hooks:
     jcristau-fx-release-metrics:
       description: Taskcluster hook to run fx release metrics


### PR DESCRIPTION
No good reason to have this so restrictive. If more than one person is studying the tutorial at a time, they can totally block each other, making it a deterrent rather than an incentive to use taskcluster.