### PR TITLE
Add a M1 macOS worker pool for proj-git-cinnabar

### DIFF
--- a/config/projects/git-cinnabar.yml
+++ b/config/projects/git-cinnabar.yml
@@ -25,12 +25,17 @@ git-cinnabar:
       scopes:
         - assume:worker-pool:proj-git-cinnabar/osx
         - assume:worker-id:proj-git-cinnabar/travis-*
+    worker-macos:
+      scopes:
+        - assume:worker-pool:proj-git-cinnabar/macos
+        - assume:worker-id:proj-git-cinnabar/gha-*
   grants:
     - grant:
         - queue:create-task:highest:proj-git-cinnabar/linux
         - queue:create-task:highest:proj-git-cinnabar/win2012r2
-        # this workerType is implemented in Github Actions (!)
+        # these two workerTypes are implemented in Github Actions (!)
         - queue:create-task:highest:proj-git-cinnabar/osx
+        - queue:create-task:highest:proj-git-cinnabar/macos
         - queue:scheduler-id:taskcluster-github
       to:
         - repo:github.com/glandium/git-cinnabar:decision-task


### PR DESCRIPTION
Eventually, I will remove the osx (x86_64) one, so I figured there's no need to add the architecture in the name.