### PR TITLE
fix: bump `maxTaskRunTime` in bugbug project to work around d2g issue

### DIFF
--- a/config/projects/bugbug.yml
+++ b/config/projects/bugbug.yml
@@ -16,6 +16,7 @@ bugbug:
         genericWorker:
           config:
             enableInteractive: true
+            maxTaskRunTime: 87500
     batch:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -28,6 +29,7 @@ bugbug:
         genericWorker:
           config:
             enableInteractive: true
+            maxTaskRunTime: 87500
     compute-smaller:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -40,6 +42,7 @@ bugbug:
         genericWorker:
           config:
             enableInteractive: true
+            maxTaskRunTime: 87500
     compute-small:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -52,6 +55,7 @@ bugbug:
         genericWorker:
           config:
             enableInteractive: true
+            maxTaskRunTime: 87500
     compute-large:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -64,6 +68,7 @@ bugbug:
         genericWorker:
           config:
             enableInteractive: true
+            maxTaskRunTime: 87500
     compute-super-large:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
@@ -76,6 +81,7 @@ bugbug:
         genericWorker:
           config:
             enableInteractive: true
+            maxTaskRunTime: 87500
   secrets:
     bugbug/deploy: true
     bugbug/integration: true


### PR DESCRIPTION
Fixes issues like this https://community-tc.services.mozilla.com/tasks/Bf6-xGlMT5igfxDfQhsAgQ/runs/1/logs/public/logs/live_backing.log

cc @marco-c