### PR TITLE
Migrate bugmon from Docker Worker to Generic Worker

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -8,25 +8,17 @@ fuzzing:
     bugmon-monitor:
       owner: jkratzer@mozilla.com
       emailOnError: false
-      imageset: docker-worker-legacy
+      imageset: generic-worker-ubuntu-22-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 5
-      workerConfig:
-        dockerConfig:
-          allowPrivileged: true
-          allowDisableSeccomp: true
     bugmon-processor:
       owner: jkratzer@mozilla.com
       emailOnError: false
-      imageset: docker-worker-legacy
+      imageset: generic-worker-ubuntu-22-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 10
-      workerConfig:
-        dockerConfig:
-          allowPrivileged: true
-          allowDisableSeccomp: true
     bugmon-processor-windows:
       owner: jkratzer@mozilla.com
       emailOnError: true


### PR DESCRIPTION
@pyoor Generic Worker can now run Docker Worker task payloads, so this _should_ work. It looks like these were set to legacy version of Docker Worker in #552 but the reason for the change isn't clear from the PR conversation, so I'm not sure what the problems were with the regular Docker Worker images.

In any case, Generic Worker should emulate all of the Docker Worker features, so hopefully things should Just Work™ with this change.

@matt-boris Do you remember why legacy was required over the standard images?