### PR TITLE
Switch proj-fuzzing/ci to generic-worker

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -47,13 +47,10 @@ fuzzing:
     ci:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false
-      imageset: docker-worker
+      imageset: generic-worker-ubuntu-22-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 20
-      workerConfig:
-        dockerConfig:
-          allowPrivileged: true
     ci-gw:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false


### PR DESCRIPTION
This will make ci-gw unnecessary, but we'll have to migrate tasks back to ci before removing it.