### PR TITLE
Change machine type for git-cinnabar linux workers

### DIFF
--- a/config/projects/git-cinnabar.yml
+++ b/config/projects/git-cinnabar.yml
@@ -10,7 +10,7 @@ git-cinnabar:
       imageset: generic-worker-ubuntu-22-04
       cloud: gcp
       maxCapacity: 5
-      machineType: "zones/{zone}/machineTypes/n2-standard-4"
+      machineType: "zones/{zone}/machineTypes/n2-highmem-4"
     win2012r2:
       imageset: generic-worker-win2022
       cloud: aws


### PR DESCRIPTION
I'm having some OOM issues with n2-standard-4, let's try with n2-highmem-4, which has the same number of vCPUs, but twice the amount of memory.