### PR TITLE
Allow any notification routes in fuzzing tasks

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -731,6 +731,7 @@ fuzzing:
         - queue:create-task:highest:proj-fuzzing/*
         - queue:scheduler-id:-
         - queue:cancel-task:-/*
+        - queue:route:notify.*
         - secrets:get:project/fuzzing/*
         - worker-manager:manage-worker-pool:proj-fuzzing/*
         - worker-manager:provider:community-tc-workers-*


### PR DESCRIPTION
@pyoor recently tried to add notifications to our fuzzing pools managed by tc-admin in the fuzzing-tc-config repo, and was hit with missing scopes. This will allow any notification routes to be created in fuzzing roles by that repo.