### PR TITLE
Add test pool for running rr under generic-worker for ProcessorTask (bugmon-pernosco)

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -108,6 +108,24 @@ generic-worker-ubuntu-24-04:
       us-west-2: ami-0a8ac2a60e18a9f78
       us-east-1: ami-0031c7517c06f35fc
       us-east-2: ami-0f796203ffd22c59c
+generic-worker-ubuntu-22-04-staging:
+  workerImplementation: generic-worker
+  workerConfig:
+    genericWorker:
+      config:
+        ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
+        shutdownMachineOnIdle: true
+        shutdownMachineOnInternalError: true
+        workerTypeMetadata:
+          machine-setup:
+            maintainer: taskcluster-notifications+workers@mozilla.com
+            script: placeholder
+  aws:
+    amis:
+      us-west-1: placeholder
+      us-west-2: placeholder
+      us-east-1: placeholder
+      us-east-2: placeholder
 generic-worker-ubuntu-24-04-arm64:
   workerImplementation: generic-worker
   workerConfig:

--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -28,6 +28,7 @@ fuzzing:
       maxCapacity: 10
       instanceTypes:
         g4ad.xlarge: 1
+        g4ad.2xlarge: 1
     bugmon-pernosco:
       owner: jkratzer@mozilla.com
       emailOnError: false
@@ -43,6 +44,18 @@ fuzzing:
           allowDisableSeccomp: true
       securityGroups:
         - docker-worker
+    bugmon-pernosco-staging:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-ubuntu-22-04-staging
+      cloud: aws
+      securityGroups:
+        - docker-worker
+        - ssh
+      minCapacity: 0
+      maxCapacity: 5
+      instanceTypes:
+        m5d.metal: 1
     ci:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -83,10 +83,10 @@ taskcluster:
     gw-ubuntu-24-04-metal:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
-      imageset: generic-worker-ubuntu-24-04
+      imageset: generic-worker-ubuntu-24-04-staging
       cloud: aws
       minCapacity: 0
-      maxCapacity: 50
+      maxCapacity: 5
       workerConfig:
         genericWorker:
           config:
@@ -95,7 +95,7 @@ taskcluster:
             idleTimeoutSecs: 3600
       # Use c5.metal to test kvm
       instanceTypes:
-        c5.metal: 1
+        m5d.metal: 1
 
     gw-ubuntu-24-04:
       owner: taskcluster-notifications+workers@mozilla.com

--- a/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
@@ -71,7 +71,10 @@ EOF
 
 # configure core dumps to be in the process' current directory with filename 'core'
 # (required for 3 legacy JS engine fuzzers)
-echo 'core' > /proc/sys/kernel/core_pattern
+echo "kernel.core_pattern = core" >> /etc/sysctl.d/90-custom.conf
+
+# fix 'bugmon-process: error: rr needs /proc/sys/kernel/perf_event_paranoid <= 1, but it is 4'
+echo 'kernel.perf_event_paranoid = 1' >> /etc/sysctl.d/90-custom.conf
 
 # create group for running snap
 groupadd snap_sudo


### PR DESCRIPTION
Currently the bugmon-pernosco ProcessorTask tasks, running in Docker Worker in AWS on bare metal workers (m5d.metal) are not running correctly under Generic Worker via d2g.

Example successful task under Docker Worker:
https://community-tc.services.mozilla.com/tasks/GJCZXWDkSf-Dv8rqZrAMSA

Task definition:
```
provisionerId: proj-fuzzing
workerType: bugmon-pernosco
taskQueueId: proj-fuzzing/bugmon-pernosco
schedulerId: '-'
projectId: none
taskGroupId: C0WNIkrsRfe9_esBSPDFZw
dependencies:
  - C0WNIkrsRfe9_esBSPDFZw
requires: all-completed
routes:
  - notify.email.jkratzer@mozilla.com.on-failed
priority: high
retries: 5
created: '2024-06-03T16:11:44.567Z'
deadline: '2024-06-03T20:11:44.567Z'
expires: '2024-06-10T16:11:44.567Z'
scopes:
  - docker-worker:capability:device:hostSharedMemory
  - docker-worker:capability:device:loopbackAudio
  - docker-worker:capability:disableSeccomp
  - docker-worker:capability:privileged
  - >-
    queue:get-artifact:project/fuzzing/bugmon/monitor-1899840-C0WNIkrsRfe9_esBSPDFZw.json
  - queue:scheduler-id:-
payload:
  env:
    BUG_ACTION: process
    TRACE_ARTIFACT: processor-rr-trace-1899840-C0WNIkrsRfe9_esBSPDFZw.tar.gz
    MONITOR_ARTIFACT: monitor-1899840-C0WNIkrsRfe9_esBSPDFZw.json
    PROCESSOR_ARTIFACT: processor-result-1899840-C0WNIkrsRfe9_esBSPDFZw.json
  cache: {}
  image:
    path: public/bugmon.tar.zst
    type: indexed-image
    namespace: project.fuzzing.orion.bugmon.master
  features:
    taskclusterProxy: true
  artifacts:
    project/fuzzing/bugmon:
      path: /bugmon-artifacts/
      type: directory
  maxRunTime: 14400
  capabilities:
    devices:
      loopbackAudio: true
      hostSharedMemory: true
    privileged: true
    disableSeccomp: true
metadata:
  name: ProcessorTask (1899840)
  owner: jkratzer@mozilla.com
  source: https://github.com/MozillaSecurity/bugmon
  description: Bugmon worker
tags: {}
extra: {}
```

Creating a test Generic Worker multiuser Linux bare metal pool in AWS to see if adding `--security-opt seccomp=unconfined` to the d2g-generated `podman run` command fixes the issue. And if not, try to work out what is needed to fix it.

Note, the current docker-worker task runs on proj-fuzzing/bugmon-pernosco which is currently running an older version of docker-worker (44.23.4): https://github.com/taskcluster/community-history/blob/3c220db2ec3938f26588d532b3140e000629cc54/WorkerVersions/proj-fuzzing%E2%81%84bugmon-pernosco#L1

This is how it interprets the `disableSeccomp: true` in the payload - that feature was removed from Docker Worker on a later release.