### PR TITLE
No need to keep the AWS proj-taskcluster Windows 2022 pools

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -72,26 +72,6 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2022
-      cloud: aws
-      securityGroups:
-        - rdp
-        - ssh
-      minCapacity: 0
-      maxCapacity: 10
-      workerConfig:
-        genericWorker:
-          config:
-            runTasksAsCurrentUser: true
-      instanceTypes:
-        m7i.2xlarge: 1
-        m7i.4xlarge: 1
-        c7i.2xlarge: 1
-        c7i.4xlarge: 1
-
-    gw-ci-windows-2022-azure:
-      owner: taskcluster-notifications+workers@mozilla.com
-      emailOnError: true
-      imageset: generic-worker-win2022
       cloud: azure
       minCapacity: 0
       maxCapacity: 10
@@ -165,22 +145,6 @@ taskcluster:
             enableInteractive: true
 
     gw-windows-2022:
-      owner: taskcluster-notifications+workers@mozilla.com
-      emailOnError: true
-      imageset: generic-worker-win2022
-      cloud: aws
-      securityGroups:
-        - rdp
-        - ssh
-      minCapacity: 0
-      maxCapacity: 10
-      instanceTypes:
-        m7i.2xlarge: 1
-        m7i.4xlarge: 1
-        c7i.2xlarge: 1
-        c7i.4xlarge: 1
-
-    gw-windows-2022-azure:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-win2022


### PR DESCRIPTION
This replaces `proj-taskcluster/gw(-ci)-windows-2022` pools with what we had in `proj-taskcluster/gw(-ci)-windows-2022-azure` pools and removes the `proj-taskcluster/gw(-ci)-windows-2022-azure` pools altogether.

As part of the migration effort from AWS to Azure, we shouldn't really need to maintain AWS and Azure versions anymore, and can just standardise on the Azure versions.