### PR TITLE
New taskcluster Windows GPU pool in Azure

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -152,13 +152,13 @@ generic-worker-win2022:
       us-east-2: ami-0ec83ef759ed8591a
   azure:
     images:
-      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-wzd4d00w8id6mpkndpp7-centralus
-      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-wzd4d00w8id6mpkndpp7-eastus
-      eastus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-wzd4d00w8id6mpkndpp7-eastus2
-      northcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-wzd4d00w8id6mpkndpp7-northcentralus
-      southcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-wzd4d00w8id6mpkndpp7-southcentralus
-      westus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-wzd4d00w8id6mpkndpp7-westus
-      westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-wzd4d00w8id6mpkndpp7-westus2
+      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-rlgv5xj1752it1ek3d9y-centralus
+      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-rlgv5xj1752it1ek3d9y-eastus
+      eastus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-rlgv5xj1752it1ek3d9y-eastus2
+      northcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-rlgv5xj1752it1ek3d9y-northcentralus
+      southcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-rlgv5xj1752it1ek3d9y-southcentralus
+      westus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-rlgv5xj1752it1ek3d9y-westus
+      westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/generic-worker-win2022-rlgv5xj1752it1ek3d9y-westus2
   workerConfig:
     genericWorker:
       config:
@@ -171,7 +171,7 @@ generic-worker-win2022:
         workerTypeMetadata:
           machine-setup:
             maintainer: pmoore@mozilla.com
-            script: https://github.com/taskcluster/community-tc-config/blob/57a68400a4c6f0832f75add22b947d8900e1216d/imagesets/generic-worker-win2022/bootstrap.ps1
+            script: https://github.com/taskcluster/community-tc-config/blob/04c12d9bc6ff975476ff53140144937ab0209e6f/imagesets/generic-worker-win2022/bootstrap.ps1
 generic-worker-win2016-amd:
   workerImplementation: generic-worker
   aws:
@@ -192,3 +192,26 @@ generic-worker-win2016-amd:
           machine-setup:
             maintainer: jkratzer@mozilla.com
             script: https://github.com/taskcluster/community-tc-config/blob/7fef75854da4a5cc23a09462b2ef33115e54c4e6/imagesets/generic-worker-win2016-amd/bootstrap.ps1
+generic-worker-win2022-gpu:
+  azure:
+    images:
+      centralus: placeholder
+      eastus: placeholder
+      eastus2: placeholder
+      northcentralus: placeholder
+      southcentralus: placeholder
+      westus: placeholder
+      westus2: placeholder
+  workerImplementation: generic-worker
+  workerConfig:
+    genericWorker:
+      config:
+        ed25519SigningKeyLocation: C:\generic-worker\generic-worker-ed25519-signing-key.key
+        livelogExecutable: C:\generic-worker\livelog.exe
+        taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
+        shutdownMachineOnIdle: true
+        idleTimeoutSecs: 15
+        shutdownMachineOnInternalError: true
+        workerTypeMetadata:
+          machine-setup:
+            maintainer: pmoore@mozilla.com

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -152,6 +152,16 @@ taskcluster:
       minCapacity: 0
       maxCapacity: 10
 
+    gw-windows-2022-gpu:
+      owner: taskcluster-notifications+workers@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-win2022-gpu
+      cloud: azure
+      minCapacity: 0
+      maxCapacity: 3
+      instanceTypes:
+        Standard_NV12s_v3: 1
+
     old-docker-worker:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
@@ -232,7 +242,6 @@ taskcluster:
         - assume:project:taskcluster:worker-test-scopes
         - assume:worker-id:docker-worker/docker-worker
         - assume:worker-id:random-local-worker/docker-worker
-        - aws-provisioner:create-secret:*
         - docker-worker:cache:docker-worker-garbage-*
         - docker-worker:capability:device:hostSharedMemory
         - docker-worker:capability:device:hostSharedMemory:null-provisioner/*

--- a/imagesets/generic-worker-win2022-gpu/aws_base_instance_type
+++ b/imagesets/generic-worker-win2022-gpu/aws_base_instance_type
@@ -1,0 +1,1 @@
+../generic-worker-win2022/aws_base_instance_type

--- a/imagesets/generic-worker-win2022-gpu/aws_filters
+++ b/imagesets/generic-worker-win2022-gpu/aws_filters
@@ -1,0 +1,1 @@
+../generic-worker-win2022/aws_filters

--- a/imagesets/generic-worker-win2022-gpu/aws_owners
+++ b/imagesets/generic-worker-win2022-gpu/aws_owners
@@ -1,0 +1,1 @@
+../generic-worker-win2022/aws_owners

--- a/imagesets/generic-worker-win2022-gpu/azure_base_instance_type
+++ b/imagesets/generic-worker-win2022-gpu/azure_base_instance_type
@@ -1,0 +1,1 @@
+Standard_NV12s_v3

--- a/imagesets/generic-worker-win2022-gpu/azure_image
+++ b/imagesets/generic-worker-win2022-gpu/azure_image
@@ -1,0 +1,1 @@
+../generic-worker-win2022/azure_image

--- a/imagesets/generic-worker-win2022-gpu/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022-gpu/bootstrap.ps1
@@ -1,0 +1,1 @@
+../generic-worker-win2022/bootstrap.ps1

--- a/imagesets/generic-worker-win2022-gpu/sysprep.ps1
+++ b/imagesets/generic-worker-win2022-gpu/sysprep.ps1
@@ -1,0 +1,1 @@
+../generic-worker-win2022/sysprep.ps1

--- a/imagesets/generic-worker-win2022/azure_image
+++ b/imagesets/generic-worker-win2022/azure_image
@@ -1,0 +1,1 @@
+MicrosoftWindowsServer:WindowsServer:2022-datacenter-azure-edition:latest

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -216,6 +216,17 @@ choco install -y visualstudio2019buildtools --version 16.5.4.0 --package-paramet
 # install gcc for go race detector
 choco install -y mingw --version 11.2.0.07112021
 
+# Get information about the video controllers (GPUs)
+$gpuInfo = Get-WmiObject -Query "Select * From Win32_VideoController"
+
+# Check if any of the video controllers are from NVIDIA
+$hasNvidiaGpu = $gpuInfo | Where-Object { $_.Name -like "*NVIDIA*" }
+
+if ($hasNvidiaGpu) {
+  $client.DownloadFile("https://download.microsoft.com/download/a/3/1/a3186ac9-1f9f-4351-a8e7-b5b34ea4e4ea/538.46_grid_win10_win11_server2019_server2022_dch_64bit_international_azure_swl.exe", "C:\nvidia_driver.exe")
+  Start-Process "C:\nvidia_driver.exe" -ArgumentList "-s", "-noreboot" -Wait -NoNewWindow -PassThru
+}
+
 # now shutdown, in preparation for creating an image
 # Stop-Computer isn't working, also not when specifying -AsJob, so reverting to using `shutdown` command instead
 #   * https://www.reddit.com/r/PowerShell/comments/65250s/windows_10_creators_update_stopcomputer_not/dgfofug/?st=j1o3oa29&sh=e0c29c6d

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -565,7 +565,7 @@ function azure_update {
   log "Creating instance ${NAME_WITH_REGION}..."
   az vm create \
     --name="${NAME_WITH_REGION}" \
-    --image=MicrosoftWindowsServer:WindowsServer:2022-datacenter-azure-edition:latest \
+    --image=$(cat azure_image) \
     --resource-group="${AZURE_VM_RESOURCE_GROUP}" \
     --computer-name="ImageBuilder" \
     --os-disk-delete-option=Delete \


### PR DESCRIPTION
This updates the images to the latest ones built, and adds a new Windows Server 2022 image set and proj-taskcluster worker pool to use it. The image set is in Azure, is essentially the same as the existing Windows 2022 image set, but additionally has an NVIDIA GPU driver installed. Note, the bootstrap script is shared between the Windows 2022 image sets, and at runtime the script determines if an NVIDIA GPU is present, and installs the driver if one is. This helps to avoid copy/paste between powershell scripts, so that we still only have a single powershell script for bootstrapping our Windows workers.