### PR TITLE
Move proj-fuzzing/grizzly-reduce-worker from docker-worker to generic-worker

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -91,7 +91,7 @@ fuzzing:
     grizzly-reduce-worker:
       owner: truber@mozilla.com
       emailOnError: true
-      imageset: docker-worker
+      imageset: generic-worker-ubuntu-22-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 20


### PR DESCRIPTION
From @jschwartzentruber:

> Just had a thought: you can switch proj-fuzzing/grizzly-reduce-worker to use generic worker and that will test that grizzly runs under d2g. That pool is defined in community-tc-config and frequently has a backlog, so it would be an easy one to test.