### PR TITLE
Reduce mozCI decision task interval to every hour

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -241,7 +241,7 @@ mozci:
       description: Run mozci classification tasks for new pushes
       owner: mcastelluccio@mozilla.com
       emailOnError: true
-      schedule: ['*/10 * * * *'] # every 10 minutes
+      schedule: ['*/60 * * * *'] # every hour
       task:
         provisionerId: proj-mozci
         workerType: compute-smaller


### PR DESCRIPTION
Because the decision tasks of the mozCI project started to cause high load on the Treeherder server with their requests,  the interval got reduced manually to every hour. Deployments (?) reset the value to the in-tree configuration. @marco-c is aware of this change.