### PR TITLE
Use c5.metal in proj-taskcluster/gw-ubuntu-24-04-aws and not in proj-misc/tutorial

### DIFF
--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -26,8 +26,6 @@ misc:
       genericWorker:
         config:
           idleTimeoutSecs: 600
-      instanceTypes:
-        c5.metal: 1
   hooks:
     jcristau-fx-release-metrics:
       description: Taskcluster hook to run fx release metrics

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -105,6 +105,9 @@ taskcluster:
           config:
             enableInteractive: true
             shutdownMachineOnInternalError: false
+      # Use c5.metal to test kvm
+      instanceTypes:
+        c5.metal: 1
 
     gw-ubuntu-24-04-gcp:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
This is a followup from #746.