### PR TITLE
Fix black check to have non-zero exit code if formatting required

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -50,7 +50,8 @@ tasks:
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
               pip install black &&
-              black --diff generate
+              black --diff generate &&
+              black --check generate
         - image: 'python:3.11'
           name: yamllint
           command:

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -506,7 +506,9 @@ def azure(
     # These constants are set in a separate file to be used by external services
     # like the fuzzing team decision tasks
     _config_path = os.path.join(os.path.dirname(__file__), "../config/azure.yml")
-    assert os.path.exists(_config_path), "Missing azure config in {}".format(_config_path)
+    assert os.path.exists(_config_path), "Missing azure config in {}".format(
+        _config_path
+    )
     azure_config = yaml.safe_load(open(_config_path))
 
     # by default, deploy where there are images
@@ -556,8 +558,7 @@ def azure(
             }
             launchConfigs.append(launchConfig)
     assert launchConfigs, (
-        f"The locations {locations} do not support instance types"
-        f" {instanceTypes}"
+        f"The locations {locations} do not support instance types" f" {instanceTypes}"
     )
 
     wp = DynamicWorkerPoolSettings(AZURE_PROVIDER)
@@ -606,9 +607,9 @@ def generic_worker(wp, **cfg):
         ).hexdigest()
 
         for launchConfig in wp.config["launchConfigs"]:
-            launchConfig["workerConfig"]["genericWorker"]["config"][
-                "deploymentId"
-            ] = hashedConfig[:16]
+            launchConfig["workerConfig"]["genericWorker"]["config"]["deploymentId"] = (
+                hashedConfig[:16]
+            )
 
         # The sentry project may be specified in the image set definition
         # (/config/imagesets.yml), or in the worker pool definition


### PR DESCRIPTION
I spotted that `black` was reporting formatting issues but CI task was passing. This PR has two commits. The first one fixes the code format failure reporting (so commit should fail CI) and the second commit formats the code, and should pass.