### PR TITLE
Increase boot disk sizes to 20GB on GCP instances

### DIFF
--- a/imagesets/generic-worker-ubuntu-22-04-arm64/gcp_filters
+++ b/imagesets/generic-worker-ubuntu-22-04-arm64/gcp_filters
@@ -1,1 +1,1 @@
---image-family=ubuntu-2204-lts-arm64 --image-project=ubuntu-os-cloud --boot-disk-size=10GB --boot-disk-type=pd-standard
+--image-family=ubuntu-2204-lts-arm64 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard

--- a/imagesets/generic-worker-ubuntu-22-04/gcp_filters
+++ b/imagesets/generic-worker-ubuntu-22-04/gcp_filters
@@ -1,1 +1,1 @@
---image-family=ubuntu-2204-lts --image-project=ubuntu-os-cloud --boot-disk-size=10GB --boot-disk-type=pd-standard
+--image-family=ubuntu-2204-lts --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard

--- a/imagesets/generic-worker-ubuntu-24-04/gcp_filters
+++ b/imagesets/generic-worker-ubuntu-24-04/gcp_filters
@@ -1,1 +1,1 @@
---image-family=ubuntu-2404-lts-amd64 --image-project=ubuntu-os-cloud --boot-disk-size=10GB --boot-disk-type=pd-standard
+--image-family=ubuntu-2404-lts-amd64 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard


### PR DESCRIPTION
This should help with problems we were getting like this:

```
2024-06-20T11:05:16.332185+00:00 generic-worker-ubuntu-24-04-kde8op53cqncn7udqclo rsyslogd[754]: rsyslogd: file '/var/log/syslog'[7] write error - see https://www.rsyslog.com/solving-rsyslog-write-errors/ for help OS error: No space left on device [v8.2312.0 try https://www.rsyslog.com/e/2027 ]
2024-06-20T11:05:16.332348+00:00 generic-worker-ubuntu-24-04-kde8op53cqncn7udqclo rsyslogd[754]: rsyslogd: action 'action-3-builtin:omfile' (module 'builtin:omfile') message lost, could not be processed. Check for additional error messages before this one. [v8.2312.0 try https://www.rsyslog.com/e/2027 ]
2024-06-20T11:05:16.332533+00:00 generic-worker-ubuntu-24-04-kde8op53cqncn7udqclo rsyslogd[754]: rsyslogd: file '/var/log/syslog'[7] write error - see https://www.rsyslog.com/solving-rsyslog-write-errors/ for help OS error: No space left on device [v8.2312.0 try https://www.rsyslog.com/e/2027 ]
```