### PR TITLE
Replace deleted security groups

### DIFF
--- a/config/aws.yml
+++ b/config/aws.yml
@@ -45,24 +45,24 @@ subnets:
 security_groups:
   us-west-1:
     no-inbound: sg-00c4014bc978171d5
-    docker-worker: sg-0d2ff88f36a05b499
-    rdp: sg-0ddc5eae2e56a43c5
-    ssh: sg-0f9ee22a4a6cef474
+    docker-worker: sg-087645ac9907433fb
+    rdp: sg-0b6238847123dd200
+    ssh: sg-0ede39e4132f5322d
 
   us-west-2:
     no-inbound: sg-0659c2937ecbe7254
-    docker-worker: sg-0f8a656368c567425
-    rdp: sg-0728e02d721b9d2c8
-    ssh: sg-0985b20410d30c5b2
+    docker-worker: sg-0823a836c2060fd8d
+    rdp: sg-099eed49a07e1bc26
+    ssh: sg-0c1d32f2472768325
 
   us-east-1:
     no-inbound: sg-07f7d21a488e192c6
-    docker-worker: sg-08fea1235cf66b102
-    rdp: sg-0f814fceb57681f0b
-    ssh: sg-04e801d56ce1f8d85
+    docker-worker: sg-01d0551837788c469
+    rdp: sg-00d1cffb677ebefc9
+    ssh: sg-05a63dba69f8ef87e
 
   us-east-2:
     no-inbound: sg-00a9d64b3595c5088
-    docker-worker: sg-0388de36e2f30ced2
-    rdp: sg-0ba932a63b653dc19
-    ssh: sg-009999abb8ebe2627
+    docker-worker: sg-0102bdcf7fc92b3e9
+    rdp: sg-0b5c6eacbbbc7dde9
+    ssh: sg-046592e27c18b856d

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -667,7 +667,7 @@ function azure_update {
   # Try to acquire an exclusive lock
   # as only one `az resource move` can
   # happen at a time
-  exec 200>azure_move_image.lock
+  exec 200> azure_move_image.lock
   flock -x 200
 
   log "Moving image ${NAME_WITH_REGION} to ${AZURE_IMAGE_RESOURCE_GROUP} resource group..."

--- a/misc/update-azure-machine-types.sh
+++ b/misc/update-azure-machine-types.sh
@@ -16,7 +16,7 @@ cd "$(dirname "${0}")"
 
 rm -f '../config/azure-machine-type-offerings.json'
 az account list-locations --query="[].name" --output tsv | sort -u | while read location; do
-  az vm list-sizes --location $location --query="[].name" --output tsv 2>/dev/null | sort -u | while read type; do
+  az vm list-sizes --location $location --query="[].name" --output tsv 2> /dev/null | sort -u | while read type; do
     echo -n "{\"name\": \"$type\", \"zone\": \"$location\"},"
   done
 done | sed 's/\(.*\)./[\1]/' | jq '.' > ../config/azure-machine-type-offerings.json


### PR DESCRIPTION
The previous security groups were removed as part of a security exercise by the Security Infrastructure team in https://mozilla-hub.atlassian.net/browse/INFRASEC-492

I have created new Security Groups by running https://github.com/taskcluster/community-tc-config/blob/34a74b2a69f09072c1f3312c5c780fdfb4ce88b6/misc/aws-worker-vpc-setup.sh

This updates the internal database with the new security group IDs.