### PR TITLE
Longer timeout for Ubuntu 24.04 workers

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -105,6 +105,7 @@ taskcluster:
           config:
             enableInteractive: true
             shutdownMachineOnInternalError: false
+            idleTimeoutSecs: 3600
       # Use c5.metal to test kvm
       instanceTypes:
         c5.metal: 1
@@ -121,6 +122,7 @@ taskcluster:
           config:
             enableInteractive: true
             shutdownMachineOnInternalError: false
+            idleTimeoutSecs: 3600
 
     gw-ubuntu-22-04-arm64:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
While setting up Ubuntu 24.04 workers, this makes life easier when I submit a task, to avoid needing to wait for a new bare metal worker to spawn each time, which can take up to 20 mins.