### PR TITLE
Increase signin-aws.sh credential validity duration (6 hours -> 24 hours)

### DIFF
--- a/imagesets/signin-aws.sh
+++ b/imagesets/signin-aws.sh
@@ -28,7 +28,7 @@ unset AWS_SECRET_ACCESS_KEY
 unset AWS_ACCESS_KEY_ID
 
 # Expiration time of login session (in seconds)
-DURATION="21600" # 6 hours
+DURATION="86400" # 24 hours
 
 # Attempt to get token from yubikey
 TOKEN=''


### PR DESCRIPTION
When rebuilding all worker pools (e.g. in https://github.com/petemoore/myscrapbook/blob/master/build-gw-images.sh) the aws credentials can timeout, since now with all the azure worker pools we have, 6 hours is often not enough. Note, it would be a lot quicker to build pools in parallel, but for now we build in serial to simplify recovery if things go wrong, and to avoid conflicts between competing updates to imageset.yml or running tc-admin etc. Bumping to 12 hours would probably have been sufficient, but setting to 24 hours should give us some peace in case the process starts taking even longer.