### PR TITLE
Move taskcluster workloads from Ubuntu 22.04 amd64 to Ubuntu 24.04 amd64

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -15,7 +15,7 @@ taskcluster:
     ci:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 10
@@ -24,7 +24,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       description: "Trusted worker to build Taskcluster releases (only!)"
       emailOnError: true
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 1
@@ -59,7 +59,7 @@ taskcluster:
     gw-ci-ubuntu-22-04:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 20
@@ -83,7 +83,7 @@ taskcluster:
     gw-ubuntu-22-04:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 50


### PR DESCRIPTION
Let's see how this goes.

Not moving staging or arm64 worker pools yet, this is migrating just the non-staging taskcluster project amd64 Ubuntu 22.04 pools.