### PR TITLE
Create ci-gw test pool for checking tasks run ok under Generic Worker

### DIFF
--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -13,11 +13,22 @@ wpt:
       launchConfig:
         advancedMachineFeatures:
           enableNestedVirtualization: true
+    ci-gw:
+      owner: pmoore@mozilla.com
+      emailOnError: true
+      imageset: generic-worker-ubuntu-24-04
+      cloud: gcp
+      minCapacity: 0
+      maxCapacity: 80
+      launchConfig:
+        advancedMachineFeatures:
+          enableNestedVirtualization: true
   repos:
     - github.com/web-platform-tests/*
   grants:
     - grant:
         - queue:create-task:highest:proj-wpt/ci
+        - queue:create-task:highest:proj-wpt/ci-gw
         - queue:create-task:highest:built-in/*
         - docker-worker:capability:privileged
         - queue:scheduler-id:taskcluster-github


### PR DESCRIPTION
@jgraham 
This creates an additional worker pool (`proj-wpt/ci-gw`) for testing the current task payloads against Generic Worker. If everything goes ok, we can update `proj-wpt/ci` to use the same settings, and drop the `proj-wpt/ci-gw` pool. This pool exists only temporarily to assist testing, so as not to interfere with production workloads until we are sure the new pool supports all of the task payloads that the current Docker Worker pool supports.