### PR TITLE
Migrate fuzzing Ubuntu 22.04 workers to Ubuntu 24.04 (includes podman upgrade)

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -8,14 +8,14 @@ fuzzing:
     bugmon-monitor:
       owner: jkratzer@mozilla.com
       emailOnError: false
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 5
     bugmon-processor:
       owner: jkratzer@mozilla.com
       emailOnError: false
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 10
@@ -46,7 +46,7 @@ fuzzing:
     ci:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 20
@@ -70,7 +70,7 @@ fuzzing:
     grizzly-reduce-worker:
       owner: truber@mozilla.com
       emailOnError: true
-      imageset: generic-worker-ubuntu-22-04
+      imageset: generic-worker-ubuntu-24-04
       cloud: gcp
       minCapacity: 0
       maxCapacity: 20


### PR DESCRIPTION
Podman 3 has some problems such as https://github.com/containers/podman/issues/16217 which may be the cause of e.g. https://community-tc.services.mozilla.com/tasks/OeEOyk4mRQu1oFX9OOXsNg/runs/0/logs/public/logs/live.log#L69.

```
+ podman run --rm -e TASK_ID -e RUN_ID -e TASKCLUSTER_ROOT_URL --add-host=taskcluster:127.0.0.1 --net=host -e TASKCLUSTER_PROXY_URL=http://localhost:80 -e PROJECT_NAME -e CI_MATRIX -e GITHUB_EVENT -e GITHUB_ACTION -e TASKCLUSTER_NOW mozillasecurity/orion-decision:latest ci-decision -v
[I] Using taskcluster credentials from environment
[I] Taskcluster Proxy enabled
[D] created git repo tmp folder: /tmp/decision-repo-kqnw6g0k
[D] calling: git init
[D] calling: git remote add origin https://github.com/MozillaSecurity/lithium
[D] calling: git fetch -t -q origin 81b53e0a07351a5a900dbc6c87c9a1d362478b6e
[D] calling: git -c advice.detachedHead=false checkout 81b53e0a07351a5a900dbc6c87c9a1d362478b6e
[D] calling: git fetch -q origin 48eb3a7397352451c1bbc3a42b30de9e84f3024d
[D] calling: git show --shortstat 48eb3a7397352451c1bbc3a42b30de9e84f3024d..81b53e0a07351a5a900dbc6c87c9a1d362478b6e
[I] task WQSu7dCDS0uoWUxEhVVJpw: Lithium tests python 3.8
[I] task YnnLbGEgS7yHdnnm4bBNiw: Lithium tests python 3.9
[I] task Zet3jv4bRBOr7Qn4zdCSmg: Lithium tests python 3.10
[I] task b5082ZGHST2H0_v04oSPxQ: Lithium tests python 3.11
[I] task Xl9SXUgsS5W62qLNFDPO-A: Lithium tests python 3.12
time="2024-07-03T20:17:11Z" level=error msg="Could not retrieve exit code from event: died not found: unable to find event"
[taskcluster 2024-07-03T20:17:11.181Z]    Exit Code: 127
[taskcluster 2024-07-03T20:17:11.181Z]    User Time: 1.277905s
[taskcluster 2024-07-03T20:17:11.181Z]  Kernel Time: 645.613ms
[taskcluster 2024-07-03T20:17:11.181Z]    Wall Time: 5.639147641s
[taskcluster 2024-07-03T20:17:11.181Z]       Result: FAILED
[taskcluster 2024-07-03T20:17:11.181Z] === Task Finished ===
```

Upgrading fuzzing pools from Ubuntu 22.04 to Ubuntu 24.04 indirectly upgrades podman from version 3 to version 4, which should hopefully resolve this issue, and pull in additional improvements/fixes.