### PR TITLE
Stop using c3-standard-8 which is having problems with networking

### DIFF
--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -34,7 +34,6 @@ mozci:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 5
-      machineType: "zones/{zone}/machineTypes/c3-standard-8"
       workerConfig:
         genericWorker:
           config:
@@ -46,7 +45,6 @@ mozci:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 5
-      machineType: "zones/{zone}/machineTypes/c3-standard-8"
       workerConfig:
         genericWorker:
           config:


### PR DESCRIPTION
We are having some problems bringing up the networking on c3-standard-8 machines...

<img width="1063" alt="Screenshot 2024-07-10 at 14 57 41" src="https://github.com/taskcluster/community-tc-config/assets/190790/bf8fe0ad-7f83-4354-8c81-54a6dc51f62e">

The same machine images work fine on the default instance types, so let's stick with those.

It looks like I set to c3-standard-8 in #674 in order [to match](https://github.com/taskcluster/community-tc-config/pull/674#issue-1884170429) the aws instance types as closely as possible. But I've spoken to @marco-c and he is happy to switch to a different instance type. At the same time, I have raised this with the gcp team [here](https://mozilla.slack.com/archives/C030ME29BEX/p1720610606700509).