### PR TITLE
Bump dependency versions to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
     url="https://github.com/taskcluster/community-tc-config",
     packages=find_packages("."),
     install_requires=[
-        "tc-admin>=4.0.0",
-        "json-e>=4.5.0",
+        "tc-admin>=4.0.1",
+        "json-e>=4.7.1",
     ],
     setup_requires=["pytest-runner"],
     tests_require=["pytest-mock", "pytest-asyncio"],


### PR DESCRIPTION
I'm not sure if there is a more idiomatic way, I don't think we have the renovate bot set up for this repo.