### PR TITLE
ubuntu24.04 disable networkd-wait-online in google

### DIFF
--- a/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
@@ -134,6 +134,12 @@ systemctl enable worker
 
 retry apt-get install -y ubuntu-desktop ubuntu-gnome-desktop podman
 
+if [ '%MY_CLOUD%' == 'google' ]; then
+    # this is neccessary in GCP because after installing gnome desktop both NetworkManager and systemd-networkd are enabled
+    # which leads to https://bugs.launchpad.net/ubuntu/jammy/+source/systemd/+bug/2036358
+    systemctl disable systemd-networkd-wait-online.service
+fi
+
 # set podman registries conf
 (
   echo '[registries.search]'


### PR DESCRIPTION
https://askubuntu.com/questions/1500473/enabling-networkmanager-makes-systemd-networkd-wait-online-fail
https://bugs.launchpad.net/ubuntu/jammy/+source/systemd/+bug/2036358