### PR TITLE
Migrate workloads back from AWS to GCP now that crisis is averted

### DIFF
--- a/config/projects/bors-ng.yml
+++ b/config/projects/bors-ng.yml
@@ -7,7 +7,7 @@ bors-ng:
       owner: michael@notriddle.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 1
   grants:

--- a/config/projects/bugbug.yml
+++ b/config/projects/bugbug.yml
@@ -9,7 +9,7 @@ bugbug:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 50
       workerConfig:
@@ -21,7 +21,7 @@ bugbug:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-2"
@@ -36,7 +36,7 @@ bugbug:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-2"
@@ -51,7 +51,7 @@ bugbug:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-4"
@@ -66,7 +66,7 @@ bugbug:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-8"
@@ -81,7 +81,7 @@ bugbug:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-16"

--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -9,14 +9,14 @@ fuzzing:
       owner: jkratzer@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 5
     bugmon-processor:
       owner: jkratzer@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
     bugmon-processor-windows:
@@ -59,7 +59,7 @@ fuzzing:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 20
     ci-windows:
@@ -73,14 +73,14 @@ fuzzing:
       owner: truber@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 5
     grizzly-reduce-worker:
       owner: truber@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 20
     grizzly-reduce-worker-android:

--- a/config/projects/git-cinnabar.yml
+++ b/config/projects/git-cinnabar.yml
@@ -8,7 +8,7 @@ git-cinnabar:
   workerPools:
     linux:
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       maxCapacity: 5
       machineType: "zones/{zone}/machineTypes/n2-highmem-4"
       instanceTypes:

--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -12,7 +12,7 @@ misc:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
       # basically everyone has access to this worker (see grants below)
@@ -20,7 +20,7 @@ misc:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 50
       genericWorker:

--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -8,14 +8,14 @@ mozci:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 50
     compute-smaller:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-2"
@@ -25,7 +25,7 @@ mozci:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 25
       machineType: "zones/{zone}/machineTypes/n2-standard-4"
@@ -35,7 +35,7 @@ mozci:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 5
       workerConfig:

--- a/config/projects/releng.yml
+++ b/config/projects/releng.yml
@@ -8,7 +8,7 @@ releng:
       owner: release@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
   grants:

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -33,7 +33,7 @@ relman:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 50
     win2022:
@@ -54,7 +54,7 @@ relman:
       owner: mcastelluccio@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 50
       workerConfig:

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -16,7 +16,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 10
 
@@ -25,7 +25,7 @@ taskcluster:
       description: "Trusted worker to build Taskcluster releases (only!)"
       emailOnError: true
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 1
       workerConfig:
@@ -60,7 +60,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 20
       workerConfig:
@@ -101,7 +101,7 @@ taskcluster:
       owner: taskcluster-notifications+workers@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 50
       workerConfig:

--- a/config/projects/webrender.yml
+++ b/config/projects/webrender.yml
@@ -12,7 +12,7 @@ webrender:
       owner: kats@mozilla.com
       emailOnError: false
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 2
   clients:

--- a/config/projects/wpt.yml
+++ b/config/projects/wpt.yml
@@ -17,7 +17,7 @@ wpt:
       owner: pmoore@mozilla.com
       emailOnError: true
       imageset: generic-worker-ubuntu-24-04
-      cloud: aws
+      cloud: gcp
       minCapacity: 0
       maxCapacity: 80
       launchConfig:


### PR DESCRIPTION
This returns worker pools back to GCP that were moved to AWS in #795.