### PR TITLE
chore: remove `idleTimeoutSecs` from our default CI pool to conserve resources

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -109,7 +109,6 @@ taskcluster:
           config:
             enableInteractive: true
             shutdownMachineOnInternalError: false
-            idleTimeoutSecs: 3600
 
     gw-ubuntu-24-04-arm64:
       owner: taskcluster-notifications+workers@mozilla.com


### PR DESCRIPTION
I've already applied these changes.