### PR TITLE
chore: add routes needed for taskgraph to build docker images

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -371,6 +371,8 @@ taskcluster:
         - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
         - queue:scheduler-id:taskcluster-level-1
         - queue:route:checks
+        - queue:route:index.taskcluster.cache.pr.docker-images.v2.*
+        - queue:route:tc-treeherder.v2.taskcluster-pr.*
       to:
         - repo:github.com/taskcluster/taskcluster:*
         - repo:github.com/taskcluster/staging-releases:*


### PR DESCRIPTION
For https://github.com/taskcluster/taskcluster/pull/7236

I've applied these changes so I can properly test the CI in that PR.