### PR TITLE
Remove proj-git-cinnabar/win2012r2

### DIFF
--- a/config/projects/git-cinnabar.yml
+++ b/config/projects/git-cinnabar.yml
@@ -13,26 +13,6 @@ git-cinnabar:
       machineType: "zones/{zone}/machineTypes/n2-highmem-4"
       instanceTypes:
         r5.xlarge: 1
-    ######################################################################
-    # This section can be removed once git-cinnabar uses the new "windows"
-    # worker pool below.
-    #
-    win2012r2:
-      imageset: generic-worker-win2022
-      cloud: azure
-      maxCapacity: 2
-      instanceTypes:
-        m7i.2xlarge: 1
-        m7i.4xlarge: 1
-        c7i.2xlarge: 1
-        c7i.4xlarge: 1
-      vmSizes:
-        Standard_F8s_v2: 1
-        Standard_F16s_v2: 1
-        Standard_D8s_v5: 1
-        Standard_D16s_v5: 1
-    #
-    ######################################################################
     windows:
       imageset: generic-worker-win2022
       cloud: azure
@@ -59,11 +39,6 @@ git-cinnabar:
   grants:
     - grant:
         - queue:create-task:highest:proj-git-cinnabar/linux
-        ##############################################################
-        # The line below can be removed once git-cinnabar uses the new
-        # "windows" worker pool
-        ##############################################################
-        - queue:create-task:highest:proj-git-cinnabar/win2012r2
         - queue:create-task:highest:proj-git-cinnabar/windows
         # these two workerTypes are implemented in Github Actions (!)
         - queue:create-task:highest:proj-git-cinnabar/osx


### PR DESCRIPTION
This completes the migration, since https://github.com/glandium/git-cinnabar/commit/adb1eed21dcc41ecdb55f1be78176e5f2b79176d landed.