### PR TITLE
Migrate Dv5 VM sizes to Dsv3 in order to support ephemeral OS disks

### DIFF
--- a/config/projects/git-cinnabar.yml
+++ b/config/projects/git-cinnabar.yml
@@ -25,8 +25,8 @@ git-cinnabar:
       vmSizes:
         Standard_F8s_v2: 1
         Standard_F16s_v2: 1
-        Standard_D8s_v5: 1
-        Standard_D16s_v5: 1
+        Standard_D8s_v3: 1
+        Standard_D16s_v3: 1
   clients:
     worker-osx:
       scopes:

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -53,8 +53,8 @@ relman:
       vmSizes:
         Standard_F8s_v2: 1
         Standard_F16s_v2: 1
-        Standard_D8s_v5: 1
-        Standard_D16s_v5: 1
+        Standard_D8s_v3: 1
+        Standard_D16s_v3: 1
     generic-worker-ubuntu-24-04:
       owner: mcastelluccio@mozilla.com
       emailOnError: false


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks

Since Dv5 family doesn't support premium storage (and thus doesn't support ephemeral OS disks) we should move to Dsv3 which is closely matched, but supports premium storage.

This should prevent the many errors we are seeing here:
* https://community-tc.services.mozilla.com/worker-manager/proj-relman%2Fwin2022/errors
* https://community-tc.services.mozilla.com/worker-manager/proj-git-cinnabar%2Fwindows/errors