### PR TITLE
Enable D2G everywhere

### DIFF
--- a/generate/workers.py
+++ b/generate/workers.py
@@ -587,9 +587,10 @@ def generic_worker(wp, **cfg):
             {
                 "genericWorker": {
                     "config": {
+                        "enableD2G": true,
+                        "idleTimeoutSecs": 600,
                         "wstAudience": "communitytc",
                         "wstServerURL": "https://community-websocktunnel.services.mozilla.com",
-                        "idleTimeoutSecs": 600,
                     },
                 },
             },


### PR DESCRIPTION
Looks like this config value is also allowed on non-Linux workers, even though I think it doesn't apply. We can follow up later to remove it from e.g. Windows workers etc if we want to.