### PR TITLE
Test reverting of CUDA installation on Windows staging

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -76,7 +76,6 @@ generic-worker-freebsd:
     genericWorker:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
-        enableInteractive: true
         idleTimeoutSecs: 15
         shutdownMachineOnIdle: true
         shutdownMachineOnInternalError: true
@@ -96,7 +95,6 @@ generic-worker-ubuntu-24-04:
     genericWorker:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
-        enableInteractive: true
         idleTimeoutSecs: 15
         shutdownMachineOnIdle: true
         shutdownMachineOnInternalError: true
@@ -118,7 +116,6 @@ generic-worker-ubuntu-24-04-arm64:
     genericWorker:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
-        enableInteractive: true
         idleTimeoutSecs: 15
         shutdownMachineOnIdle: true
         shutdownMachineOnInternalError: true
@@ -134,10 +131,8 @@ generic-worker-ubuntu-24-04-staging:
     genericWorker:
       config:
         ed25519SigningKeyLocation: /etc/generic-worker/ed25519_key
-        enableInteractive: true
         idleTimeoutSecs: 15
         shutdownMachineOnIdle: true
-        shutdownMachineOnInternalError: false
         workerTypeMetadata:
           machine-setup:
             maintainer: taskcluster-notifications+workers@mozilla.com
@@ -198,7 +193,6 @@ generic-worker-win2022-staging:
         idleTimeoutSecs: 15
         livelogExecutable: C:\generic-worker\livelog.exe
         shutdownMachineOnIdle: true
-        shutdownMachineOnInternalError: true
         taskclusterProxyExecutable: C:\generic-worker\taskcluster-proxy.exe
         workerTypeMetadata:
           machine-setup:

--- a/config/projects/bugbug.yml
+++ b/config/projects/bugbug.yml
@@ -15,7 +15,6 @@ bugbug:
       workerConfig:
         genericWorker:
           config:
-            enableInteractive: true
             maxTaskRunTime: 87500
     batch:
       owner: mcastelluccio@mozilla.com
@@ -30,7 +29,6 @@ bugbug:
       workerConfig:
         genericWorker:
           config:
-            enableInteractive: true
             maxTaskRunTime: 87500
     compute-smaller:
       owner: mcastelluccio@mozilla.com
@@ -45,7 +43,6 @@ bugbug:
       workerConfig:
         genericWorker:
           config:
-            enableInteractive: true
             maxTaskRunTime: 87500
     compute-small:
       owner: mcastelluccio@mozilla.com
@@ -60,7 +57,6 @@ bugbug:
       workerConfig:
         genericWorker:
           config:
-            enableInteractive: true
             maxTaskRunTime: 87500
     compute-large:
       owner: mcastelluccio@mozilla.com
@@ -75,7 +71,6 @@ bugbug:
       workerConfig:
         genericWorker:
           config:
-            enableInteractive: true
             maxTaskRunTime: 87500
     compute-super-large:
       owner: mcastelluccio@mozilla.com
@@ -90,7 +85,6 @@ bugbug:
       workerConfig:
         genericWorker:
           config:
-            enableInteractive: true
             maxTaskRunTime: 87500
   secrets:
     bugbug/deploy: true

--- a/config/projects/mozci.yml
+++ b/config/projects/mozci.yml
@@ -38,10 +38,6 @@ mozci:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 5
-      workerConfig:
-        genericWorker:
-          config:
-            enableInteractive: true
   secrets:
     testing: true
     production: true

--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -62,10 +62,6 @@ relman:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 50
-      workerConfig:
-        genericWorker:
-          config:
-            enableInteractive: true
 
   secrets:
     bugzilla-dashboard-backend/deploy-production: true

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -90,9 +90,11 @@ taskcluster:
       workerConfig:
         genericWorker:
           config:
-            enableInteractive: true
-            shutdownMachineOnInternalError: false
+            # this pool isn't in regular use, and when we use it, it is
+            # typically for testing bare metal stuff, so nice to have
+            # longer timeout
             idleTimeoutSecs: 3600
+            shutdownMachineOnInternalError: false
       # Use c5.metal to test kvm
       instanceTypes:
         m5d.metal: 1
@@ -104,11 +106,6 @@ taskcluster:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 50
-      workerConfig:
-        genericWorker:
-          config:
-            enableInteractive: true
-            shutdownMachineOnInternalError: false
 
     gw-ubuntu-24-04-arm64:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -117,10 +114,6 @@ taskcluster:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 5
-      workerConfig:
-        genericWorker:
-          config:
-            enableInteractive: true
       machineType: "zones/{zone}/machineTypes/t2a-standard-4"
 
     gw-ubuntu-staging-aws:
@@ -136,7 +129,7 @@ taskcluster:
             # While iterating on the image building process for this worker
             # pool, useful for workers not to die immediately...
             idleTimeoutSecs: 3600
-            enableInteractive: true
+            shutdownMachineOnInternalError: false
 
     gw-ubuntu-staging-google:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -159,7 +152,7 @@ taskcluster:
             # While iterating on the image building process for this worker
             # pool, useful for workers not to die immediately...
             idleTimeoutSecs: 3600
-            enableInteractive: true
+            shutdownMachineOnInternalError: false
 
     gw-windows-2022:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -176,12 +169,16 @@ taskcluster:
       cloud: azure
       minCapacity: 0
       maxCapacity: 10
+      # Currently staging uses a GPU pool so we can also test GPU related changes
+      vmSizes:
+        Standard_NV12s_v3: 1
       workerConfig:
         genericWorker:
           config:
             # While iterating on the image building process for this worker
             # pool, useful for workers not to die immediately...
             idleTimeoutSecs: 3600
+            shutdownMachineOnInternalError: false
 
     gw-windows-2022-gpu:
       owner: taskcluster-notifications+workers@mozilla.com

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -588,6 +588,7 @@ def generic_worker(wp, **cfg):
                 "genericWorker": {
                     "config": {
                         "enableD2G": True,
+                        "enableInteractive": True,
                         "idleTimeoutSecs": 600,
                         "wstAudience": "communitytc",
                         "wstServerURL": "https://community-websocktunnel.services.mozilla.com",

--- a/imagesets/generic-worker-win2022-staging/azure_base_instance_type
+++ b/imagesets/generic-worker-win2022-staging/azure_base_instance_type
@@ -1,1 +1,1 @@
-../generic-worker-win2022/azure_base_instance_type
+../generic-worker-win2022-gpu/azure_base_instance_type

--- a/imagesets/generic-worker-win2022-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022-staging/bootstrap.ps1
@@ -225,8 +225,11 @@ if ($hasNvidiaGpu) {
   Start-Process "C:\nvidia_driver.exe" -ArgumentList "-s", "-noreboot" -Wait -NoNewWindow -RedirectStandardOutput "C:\nvidia-install-stdout.txt" -RedirectStandardError "C:\nvidia-install-stderr.txt"
   # install CUDA
   # https://github.com/taskcluster/community-tc-config/issues/713
-  $client.DownloadFile("https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.94_windows.exe", "C:\cuda_installer.exe")
-  Start-Process "C:\cuda_installer.exe" -ArgumentList "-s", "-noreboot" -Wait -NoNewWindow -RedirectStandardOutput "C:\cuda-install-stdout.txt" -RedirectStandardError "C:\cuda-install-stderr.txt"
+
+  # Test removing this in staging to see if it fixes things...
+  # $client.DownloadFile("https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.94_windows.exe", "C:\cuda_installer.exe")
+  # Start-Process "C:\cuda_installer.exe" -ArgumentList "-s", "-noreboot" -Wait -NoNewWindow -RedirectStandardOutput "C:\cuda-install-stdout.txt" -RedirectStandardError "C:\cuda-install-stderr.txt"
+
 }
 
 # now shutdown, in preparation for creating an image


### PR DESCRIPTION
This reverts the CUDA changes on Windows Staging (which seems to have broken Windows GPU pools in #830).

Note, this reverts it only from staging, so that we don't test in production (even though production GPU pools are probably broken, it is a good habit to get into).

It might be worth trying one last time to build with the CUDA installation on staging, or alternatively, we could revert on staging, and then use a pool where we run as root, get an RDP session on it, running as root, and see what is going wrong when we manually RDP onto it and execute the installation steps.

Weirdly, the installation seems to happen, but it seems to break the worker somehow, because workers were getting spawned, but not calling Worker Manager to get credentials, as far as I can tell.

At the same time, I enabled interactive on all worker pools in community, because I can't think of a good reason we would ever want to disable it. If that changes, we can set it at a worker pool level later, but for now, I think we should just keep things simple and have it enabled everywhere, until that becomes a problem.