### PR TITLE
Exit powershell on bootstrap failure

### DIFF
--- a/imagesets/generic-worker-win2022-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022-staging/bootstrap.ps1
@@ -1,7 +1,7 @@
 $TASKCLUSTER_REF = "main"
 
 # Exit the script on any powershell command error
-# $ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -47,7 +47,7 @@ function Run-Executable {
     # Check the exit code and exit if non-zero
     if ($LASTEXITCODE -ne 0) {
         Write-Host "The command failed with exit code $LASTEXITCODE"
-        # exit $LASTEXITCODE
+        exit $LASTEXITCODE
     }
 
     # Return the output


### PR DESCRIPTION
Before we land this, I just wanted to build one time without it, as a last chance to fix anything that might be broken (which should be visible from the logs in `C:\Install Logs`). Once there are no failures, it makes sense to enable this.