### PR TITLE
Some tweaks to image set building

### DIFF
--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -244,9 +244,9 @@ function deploy {
 
   retry git -c pull.rebase=true pull "${OFFICIAL_GIT_REPO}" main
   retry git push "${OFFICIAL_GIT_REPO}" "+HEAD:refs/heads/main"
-  log 'Deployment of image sets successful!'
+  log "Deployment of image set ${IMAGE_SET} successful"
   log ''
-  log 'Be sure to run tc-admin in the community-tc-config repo to apply changes to the community cluster!'
+  log 'Be sure to run tc-admin to apply changes to the community cluster!'
 }
 
 ################## AWS ##################


### PR DESCRIPTION
Hopefully this will:

  * reduce problems due to passphrases expiring
  * show reason why we got

```
imageset.sh: 2024-10-11T17:54:55Z: aws: generic-worker-win2022: us-east-1: Cannot deploy in us-east-1 since instance type c4.2xlarge is not supported; skipping.
imageset.sh: 2024-10-11T17:54:56Z: aws: generic-worker-win2022: us-east-2: Cannot deploy in us-east-2 since instance type c4.2xlarge is not supported; skipping.
imageset.sh: 2024-10-11T17:54:56Z: aws: generic-worker-win2022: us-west-1: Cannot deploy in us-west-1 since instance type c4.2xlarge is not supported; skipping.
imageset.sh: 2024-10-11T17:54:57Z: aws: generic-worker-win2022: us-west-2: Cannot deploy in us-west-2 since instance type c4.2xlarge is not supported; skipping.
```

since clearly it wasn't because the instance type wasn't supported (since it is). When we find out exactly what the error looks like when the instance type is not supported, we can grep it, and if the reason is something else, retry it and log it.