### PR TITLE
Completely replace old image sets when a new one is built

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -179,10 +179,8 @@ generic-worker-win2022-staging:
   workerImplementation: generic-worker
   azure:
     images:
-      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-nq7412idao1upt6aozl4-centralus
       eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-cho2b67efi8no0fgdz65-eastus
       eastus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-cho2b67efi8no0fgdz65-eastus2
-      northcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-nq7412idao1upt6aozl4-northcentralus
       southcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-cho2b67efi8no0fgdz65-southcentralus
       westus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-cho2b67efi8no0fgdz65-westus
       westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-cho2b67efi8no0fgdz65-westus2

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -182,6 +182,10 @@ function deploy {
       log "Fetching secrets..."
       retry pass git pull
       for REGION in us-west-1 us-west-2 us-east-1 us-east-2; do
+        # Delete any preexisting value, in case we don't have a new one, e.g.
+        # because we have switched instance type and the new one is not available
+        # in a given region.
+        yq d -i ../config/imagesets.yml "${IMAGE_SET}.aws.amis.${REGION}" # returns with exit code 0 even if entry doesn't exist
         # some regions may not have secrets if they do not support the required instance type
         if [ -f "${IMAGE_SET}/aws.${REGION}.secrets" ]; then
           IMAGE_ID="$(cat "${IMAGE_SET}/aws.${REGION}.secrets" | sed -n 's/^AMI: *//p')"
@@ -202,6 +206,11 @@ function deploy {
       log "Fetching secrets..."
       retry pass git pull
       for REGION in centralus eastus eastus2 northcentralus southcentralus westus westus2; do
+        # Delete any preexisting value, in case we don't have a new one, e.g.
+        # because we have switched instance type and the new one is not available
+        # in a given region.
+        yq d -i ../config/imagesets.yml "${IMAGE_SET}.azure.images.${REGION}" # returns with exit code 0 even if entry doesn't exist
+        # some regions may not have secrets if they do not support the required instance type
         # some regions may not have secrets if they do not support the required instance type
         if [ -f "${IMAGE_SET}/azure.${REGION}.secrets" ]; then
           IMAGE_ID="$(cat "${IMAGE_SET}/azure.${REGION}.secrets" | sed -n 's/^Image: *//p')"


### PR DESCRIPTION
If we switched instance type, e.g. in staging, to an instance type that didn't exist in some regions, we could end up having workers on old versions in those regions! 😬 