### PR TITLE
chore: remove gpg preset passphrase setup

### DIFF
--- a/imagesets/README.md
+++ b/imagesets/README.md
@@ -73,21 +73,8 @@ to be present:
    following content to file `~/.gnupg/gpg-agent.conf`:
 
    ```
-   allow-preset-passphrase
    default-cache-ttl 86400
    max-cache-ttl 86400
-   ```
-
-   and having the following executed (e.g. in your .profile / .bashrc), or run manually
-   before you build images:
-
-   ```
-   gpg_email='<your-username>@mozilla.com'
-   read -p "Please enter the GPG passphrase for ${gpg_email}: " gpg_passphrase
-
-   gpg -k --with-keygrip "${gpg_email}" | sed -n 's/.*Keygrip = //p' | while read keygrip; do
-     echo "${gpg_passphrase}" | "$(gpgconf --list-dirs libexecdir)"/gpg-preset-passphrase --preset "${keygrip}"
-   done
    ```
 
 Once all of the above prerequisite steps have been made, you are in a position

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -920,17 +920,6 @@ IMAGESETS_DIR="$(pwd)"
 
 export OFFICIAL_GIT_REPO='git@github.com:taskcluster/community-tc-config'
 
-if [ -z "${GPG_SIGNING_CONFIGURED-}" ]; then
-  gpg_email="$(git config user.email)"
-  read -s -p "Please enter the GPG passphrase (for ${gpg_email}): " gpg_passphrase
-  gpg -k --with-keygrip "${gpg_email}" | sed -n 's/.*Keygrip = //p' | while read keygrip; do
-    echo "${gpg_passphrase}" | "$(gpgconf --list-dirs libexecdir)"/gpg-preset-passphrase --preset "${keygrip}"
-  done
-  unset gpg_passphrase
-  export GPG_SIGNING_CONFIGURED=true
-fi
-echo "Ensuring gpg signing is working before proceeding..." | gpg --clearsign
-
 if [ "${1-}" == "all" ]; then
   all-in-parallel
   exit 0


### PR DESCRIPTION
I don't think these steps are necessary, so long as you have:
```
    default-cache-ttl 86400
    max-cache-ttl 86400
```
in your `~/.gnupg/gpg-agent.conf` file