### PR TITLE
fix: delete azure resource groups after build too

### DIFF
--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -898,6 +898,13 @@ function all-in-parallel {
     imagesets/imageset.sh aws update docker-worker &
 
     wait
+
+    if [ -n "${DELETE_OLD_RGS}" ]; then
+      for rg in $(az group list --query "[?starts_with(name, 'imageset-')].name" -o tsv); do
+        echo "Deleting old resource group ${rg}..."
+        az group delete --name $rg --yes --no-wait
+      done
+    fi
   fi
 
   if [ -n "${DEPLOY_IMAGES}" ]; then


### PR DESCRIPTION
Otherwise, lots of resources will stick around (affecting quotas, for example) after every build, in azure.