### PR TITLE
chore: small cleanup around installing kernel modules

### DIFF
--- a/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
@@ -154,8 +154,8 @@ fi
   echo 'registries=["docker.io"]'
 ) >> /etc/containers/registries.conf
 
-# Installs the v4l2loopback kernel module
-# used for the video device, and vkms
+# Installs the snd-aloop, v4l2loopback kernel modules
+# used for the audio/video devices, and vkms
 # required by Wayland
 retry apt-get install -y linux-modules-extra-$(uname -r)
 # needed for mutter to work with DRM rather than falling back to X11
@@ -168,10 +168,6 @@ sed '/platform-vkms/d' /lib/udev/rules.d/61-mutter.rules > /etc/udev/rules.d/61-
 # https://help.ubuntu.com/community/KVM/Installation
 retry apt-get install -y qemu-kvm bridge-utils
 
-# install extra modules for snd-aloop kernel module
-if [ '%MY_CLOUD%' == 'google' ]; then
-  retry apt-get install -y linux-modules-extra-gcp
-fi
 echo 'options snd-aloop enable=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 index=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31' > /etc/modprobe.d/snd-aloop.conf
 echo 'snd-aloop' >> /etc/modules
 

--- a/imagesets/generic-worker-ubuntu-24-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04/bootstrap.sh
@@ -140,8 +140,8 @@ fi
   echo 'registries=["docker.io"]'
 ) >> /etc/containers/registries.conf
 
-# Installs the v4l2loopback kernel module
-# used for the video device, and vkms
+# Installs the snd-aloop, v4l2loopback kernel modules
+# used for the audio/video devices, and vkms
 # required by Wayland
 retry apt-get install -y linux-modules-extra-$(uname -r)
 # needed for mutter to work with DRM rather than falling back to X11
@@ -154,10 +154,6 @@ sed '/platform-vkms/d' /lib/udev/rules.d/61-mutter.rules > /etc/udev/rules.d/61-
 # https://help.ubuntu.com/community/KVM/Installation
 retry apt-get install -y qemu-kvm bridge-utils
 
-# install extra modules for snd-aloop kernel module
-if [ '%MY_CLOUD%' == 'google' ]; then
-  retry apt-get install -y linux-modules-extra-gcp
-fi
 echo 'options snd-aloop enable=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 index=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31' > /etc/modprobe.d/snd-aloop.conf
 echo 'snd-aloop' >> /etc/modules
 


### PR DESCRIPTION
Cleanup from https://github.com/taskcluster/community-tc-config/pull/887. I hadn't realized we were installing `linux-modules-extra-$(uname -r)` which should be sufficient. I think the fix for GCP is creating the `/etc/modprobe.d/snd-aloop.conf` options file alongside adding `snd-aloop` to `/etc/modules`.