### PR TITLE
fix: remove broken install link for gvim

### DIFF
--- a/imagesets/generic-worker-win2022-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022-staging/bootstrap.ps1
@@ -200,9 +200,6 @@ $hostsFileLines = @(
 # Append the lines to the hosts file
 Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value $hostsFileLines
 
-# download gvim
-Invoke-WebRequest -Uri "https://artfiles.org/vim.org/pc/gvim80-069.exe" -OutFile "C:\Downloads\gvim80-069.exe"
-
 # open up firewall for livelog (both PUT and GET interfaces)
 New-NetFirewallRule -DisplayName "Allow livelog PUT requests" -Direction Inbound -LocalPort 60022 -Protocol TCP -Action Allow
 New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound -LocalPort 60023 -Protocol TCP -Action Allow

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -197,9 +197,6 @@ $hostsFileLines = @(
 # Append the lines to the hosts file
 Add-Content -Path "C:\Windows\System32\drivers\etc\hosts" -Value $hostsFileLines
 
-# download gvim
-Invoke-WebRequest -Uri "https://artfiles.org/vim.org/pc/gvim80-069.exe" -OutFile "C:\Downloads\gvim80-069.exe"
-
 # open up firewall for livelog (both PUT and GET interfaces)
 New-NetFirewallRule -DisplayName "Allow livelog PUT requests" -Direction Inbound -LocalPort 60022 -Protocol TCP -Action Allow
 New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound -LocalPort 60023 -Protocol TCP -Action Allow


### PR DESCRIPTION
The recent windows image rollout for v77 failed due to the following issue in the install logs:
```powershell
PS>TerminatingError(Invoke-WebRequest): "<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.29 (Ubuntu) Server at artfiles.org Port 443</address>
</body></html>
"
```

Looking into the artfiles.org download for gvim, I see no more `.exe`s are available to download https://artfiles.org/vim.org/pc/. I think this is safe to remove so we're unblocked for now, as I believe it's only being installed for debugging purposes.