### PR TITLE
Add `queue:route:checks` to the git-cinnabar project

### DIFF
--- a/config/projects/git-cinnabar.yml
+++ b/config/projects/git-cinnabar.yml
@@ -44,6 +44,7 @@ git-cinnabar:
         - queue:create-task:highest:proj-git-cinnabar/osx
         - queue:create-task:highest:proj-git-cinnabar/macos
         - queue:scheduler-id:taskcluster-github
+        - queue:route:checks
       to:
         - repo:github.com/glandium/git-cinnabar:decision-task
 


### PR DESCRIPTION
I'm interested in testing [taskcluster-github checks](https://docs.taskcluster.net/docs/reference/integrations/github/checks)