### PR TITLE
Remove the covdiff fuzzing hook

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -677,45 +677,6 @@ fuzzing:
         provisionerId: proj-fuzzing
       schedule:
         - "0 8 * * 1"
-    covdiff:
-      description: Hook for downloading, merging, and submitting Mozilla CI coverage reports
-      owner: jkratzer@mozilla.com
-      emailOnError: true
-      task:
-        routes:
-          - notify.email.jkratzer@mozilla.com.on-failed
-        scopes:
-          - docker-worker:capability:privileged
-          - queue:get-artifact:project/fuzzing/covdiff/*
-          - queue:route:notify.email.jkratzer@mozilla.com.on-failed
-          - queue:scheduler-id:-
-          - secrets:get:project/fuzzing/fuzzmanagerconf
-          - secrets:get:project/fuzzing/moz-ci-coverage-key
-        expires:
-          $fromNow: 1 months
-        payload:
-          image:
-            path: public/covdiff.tar.zst
-            type: indexed-image
-            namespace: project.fuzzing.orion.covdiff.master
-          features:
-            taskclusterProxy: true
-          artifacts:
-            project/fuzzing/covdiff:
-              path: /live.log
-              type: file
-          maxRunTime: 10800
-        deadline:
-          $fromNow: 6 hours
-        metadata:
-          name: covdiff
-          owner: jkratzer@mozilla.com
-          source: https://github.com/MozillaSecurity/covdiff
-          description: Hook for downloading, merging, and submitting Mozilla CI coverage reports
-        workerType: ci
-        provisionerId: proj-fuzzing
-      schedule:
-        - "0 10 * * 1"
     orion-cron:
       description: Periodically check if any Orion services need to be rebuilt
       owner: truber@mozilla.com
@@ -968,16 +929,6 @@ fuzzing:
         - secrets:get:project/fuzzing/deploy-npm
       to:
         - hook-id:project-fuzzing/gr-idl-update
-    - grant:
-        - docker-worker:capability:privileged
-        - queue:create-task:highest:proj-fuzzing/ci
-        - queue:get-artifact:project/fuzzing/covdiff/*
-        - queue:route:notify.email.jkratzer@mozilla.com.on-failed
-        - queue:scheduler-id:-
-        - secrets:get:project/fuzzing/fuzzmanagerconf
-        - secrets:get:project/fuzzing/moz-ci-coverage-key
-      to:
-        - hook-id:project-fuzzing/covdiff
     - grant:
         - docker-worker:capability:privileged
         - queue:create-task:highest:proj-fuzzing/nss-corpus-update-worker


### PR DESCRIPTION
The underlying data source has been broken for several months and it's not clear when or if it will be fixed.  Removing the hook for now.