### PR TITLE
fix: add gdm3 startup delay to give wayland time 

### DIFF
--- a/imagesets/generic-worker-freebsd/bootstrap.sh
+++ b/imagesets/generic-worker-freebsd/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/csh
 
 # Version numbers ####################
-setenv TASKCLUSTER_VERSION v78.2.0
+setenv TASKCLUSTER_VERSION v79.0.0
 ######################################
 
 pkg update

--- a/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
@@ -83,7 +83,7 @@ echo '%snap_sudo ALL=(ALL:ALL) NOPASSWD: /usr/bin/snap' | EDITOR='tee -a' visudo
 
 # build generic-worker/livelog/start-worker/taskcluster-proxy from ${TASKCLUSTER_REF} commit / branch / tag etc
 retry apt-get install -y git tar
-retry curl -fsSL 'https://dl.google.com/go/go1.23.1.linux-amd64.tar.gz' > go.tar.gz
+retry curl -fsSL 'https://dl.google.com/go/go1.23.5.linux-amd64.tar.gz' > go.tar.gz
 tar xvfz go.tar.gz -C /usr/local
 export HOME=/root
 export GOPATH=~/go

--- a/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04-staging/bootstrap.sh
@@ -214,10 +214,10 @@ crudini --set /etc/gdm3/custom.conf daemon XorgEnable 'false'
 mkdir -p /etc/systemd/system/gdm.service.d/
 cat > /etc/systemd/system/gdm.service.d/gdm-wait.conf << EOF
 [Unit]
-Description=Extra 5s wait
+Description=Extra 10s wait
 
 [Service]
-ExecStartPre=/bin/sleep 5
+ExecStartPre=/bin/sleep 10
 EOF
 
 #

--- a/imagesets/generic-worker-ubuntu-24-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04/bootstrap.sh
@@ -154,6 +154,87 @@ sed '/platform-vkms/d' /lib/udev/rules.d/61-mutter.rules > /etc/udev/rules.d/61-
 echo 'options snd-aloop enable=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 index=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31' > /etc/modprobe.d/snd-aloop.conf
 echo 'snd-aloop' >> /etc/modules
 
+# used to modify specific blocks in .conf files
+retry apt-get install -y crudini
+
+#
+# dconf settings
+#
+cat > /etc/dconf/profile/user << EOF
+user-db:user
+system-db:local
+EOF
+
+mkdir /etc/dconf/db/local.d/
+# dconf user settings
+cat > /etc/dconf/db/local.d/00-tc-gnome-settings << EOF
+# /org/gnome/desktop/session/idle-delay
+[org/gnome/desktop/session]
+idle-delay=uint32 0
+
+# /org/gnome/desktop/lockdown/disable-lock-screen
+[org/gnome/desktop/lockdown]
+disable-lock-screen=true
+EOF
+
+# make dbus read the new configuration
+dconf update
+
+#
+# gdm3 settings  
+#
+# in [daemon] block of /etc/gdm3/custom.conf we need:
+#
+# XorgEnable=false
+crudini --set /etc/gdm3/custom.conf daemon XorgEnable 'false'
+
+#
+# gdm wait service file
+#
+# This hack is required because without we end up in a situation where the
+# wayland seat is in a weird state and consequences are:
+#    - either x11 session
+#    - either xwayland fallback
+#    - either wayland but with missing keyboard capability that breaks
+#        things including copy/paste
+mkdir -p /etc/systemd/system/gdm.service.d/
+cat > /etc/systemd/system/gdm.service.d/gdm-wait.conf << EOF
+[Unit]
+Description=Extra 10s wait
+
+[Service]
+ExecStartPre=/bin/sleep 10
+EOF
+
+#
+# write mutter's monitors.xml
+#
+cat > /etc/xdg/monitors.xml << EOF
+<monitors version="2">
+  <configuration>
+    <logicalmonitor>
+      <x>0</x>
+      <y>0</y>
+      <scale>1</scale>
+      <primary>yes</primary>
+      <monitor>
+        <monitorspec>
+          <connector>Virtual-1</connector>
+          <vendor>unknown</vendor>
+          <product>unknown</product>
+          <serial>unknown</serial>
+        </monitorspec>
+        <mode>
+          <width>1920</width>
+          <height>1080</height>
+          <rate>60.000</rate>
+        </mode>
+      </monitor>
+    </logicalmonitor>
+  </configuration>
+</monitors>
+EOF
+
 # avoid unnecessary shutdowns during worker startups
 systemctl disable unattended-upgrades
 

--- a/imagesets/generic-worker-ubuntu-24-04/bootstrap.sh
+++ b/imagesets/generic-worker-ubuntu-24-04/bootstrap.sh
@@ -4,7 +4,7 @@ set -exv
 exec &> /var/log/bootstrap.log
 
 # Version numbers ####################
-TASKCLUSTER_VERSION='v78.2.0'
+TASKCLUSTER_VERSION='v79.0.0'
 ######################################
 
 function retry {

--- a/imagesets/generic-worker-win2022-staging/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022-staging/bootstrap.ps1
@@ -205,7 +205,7 @@ New-NetFirewallRule -DisplayName "Allow livelog PUT requests" -Direction Inbound
 New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound -LocalPort 60023 -Protocol TCP -Action Allow
 
 # install go
-Expand-ZIPFile -File "C:\Downloads\go1.23.1.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.23.1.windows-amd64.zip"
+Expand-ZIPFile -File "C:\Downloads\go1.23.5.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.23.5.windows-amd64.zip"
 Move-Item -Path "C:\go" -Destination "C:\goroot"
 
 # install git

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -202,7 +202,7 @@ New-NetFirewallRule -DisplayName "Allow livelog PUT requests" -Direction Inbound
 New-NetFirewallRule -DisplayName "Allow livelog GET requests" -Direction Inbound -LocalPort 60023 -Protocol TCP -Action Allow
 
 # install go
-Expand-ZIPFile -File "C:\Downloads\go1.23.1.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.23.1.windows-amd64.zip"
+Expand-ZIPFile -File "C:\Downloads\go1.23.5.windows-amd64.zip" -Destination "C:\" -Url "https://storage.googleapis.com/golang/go1.23.5.windows-amd64.zip"
 Move-Item -Path "C:\go" -Destination "C:\goroot"
 
 # install git

--- a/imagesets/generic-worker-win2022/bootstrap.ps1
+++ b/imagesets/generic-worker-win2022/bootstrap.ps1
@@ -1,4 +1,4 @@
-$TASKCLUSTER_VERSION = "v78.2.0"
+$TASKCLUSTER_VERSION = "v79.0.0"
 
 # Write-Log function for logging with RFC3339 format timestamps
 function Write-Log {


### PR DESCRIPTION
This change gets us more in line with what they do for FxCI https://github.com/mozilla-platform-ops/worker-images/blob/main/scripts/linux/ubuntu-2404-amd64-gui/fxci/04-wayland.sh

I've decreased the delay from 30s to 10s and we can go from there.

I've also bumped the taskcluster version and the go binary version downloaded.