### PR TITLE
chore: bump base ubuntu image version to v20250130

### DIFF
--- a/imagesets/generic-worker-ubuntu-24-04-arm64/gcp_filters
+++ b/imagesets/generic-worker-ubuntu-24-04-arm64/gcp_filters
@@ -1,1 +1,1 @@
---image=ubuntu-2404-noble-arm64-v20250117 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard
+--image=ubuntu-2404-noble-arm64-v20250130 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard

--- a/imagesets/generic-worker-ubuntu-24-04/gcp_filters
+++ b/imagesets/generic-worker-ubuntu-24-04/gcp_filters
@@ -1,1 +1,1 @@
---image=ubuntu-2404-noble-amd64-v20250117 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard
+--image=ubuntu-2404-noble-amd64-v20250130 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard


### PR DESCRIPTION
Simple test was successful on the staging pool first https://community-tc.services.mozilla.com/provisioners/proj-taskcluster/worker-types/gw-ubuntu-staging-google/workers/us-east4-b/3511232623394459624?sortBy=started&sortDirection=desc

https://community-tc.services.mozilla.com/tasks/YR1EIPnfTUCp5pcKU_O6Hw