### PR TITLE
chore: stop building docker worker images during `./imageset.sh all`

### DIFF
--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -895,10 +895,6 @@ function all-in-parallel {
     imagesets/imageset.sh aws update generic-worker-ubuntu-24-04 &
     imagesets/imageset.sh google update generic-worker-ubuntu-24-04-arm64 &
 
-    ########## Docker Worker ##########
-    imagesets/imageset.sh google update docker-worker &
-    imagesets/imageset.sh aws update docker-worker &
-
     if "${BUILD_STAGING_IMAGES}"; then
       imagesets/imageset.sh azure update generic-worker-win2022-staging &
       imagesets/imageset.sh azure update generic-worker-win11-24h2-staging &


### PR DESCRIPTION
I don't think this is needed anymore, especially while building our production images for community tc. Seems like a waste of resources.