### PR TITLE
chore: bump `idleTimeoutSecs` for taskcluster CI pools for caches

### DIFF
--- a/config/projects/misc.yml
+++ b/config/projects/misc.yml
@@ -23,9 +23,6 @@ misc:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 50
-      genericWorker:
-        config:
-          idleTimeoutSecs: 600
   hooks:
     jcristau-fx-release-metrics:
       description: Taskcluster hook to run fx release metrics

--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -36,6 +36,7 @@ taskcluster:
         genericWorker:
           config:
             headlessTasks: true
+            idleTimeoutSecs: 300
 
     # *-gui worker pools are for generic-worker CI
     # they all have `headlessTasks: false` in
@@ -75,6 +76,7 @@ taskcluster:
             # a GUI, and thus we shouldn't enable Headless (disable GUI) on the
             # CI environment itself.
             headlessTasks: false
+            idleTimeoutSecs: 300
 
     gw-windows-2022-gui:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -93,6 +95,7 @@ taskcluster:
             # a GUI, and thus we shouldn't enable Headless (disable GUI) on the
             # CI environment itself.
             headlessTasks: false
+            idleTimeoutSecs: 300
 
     gw-ubuntu-24-04-metal:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -127,6 +130,7 @@ taskcluster:
         genericWorker:
           config:
             headlessTasks: true
+            idleTimeoutSecs: 300
 
     gw-ubuntu-24-04-arm64:
       owner: taskcluster-notifications+workers@mozilla.com
@@ -196,6 +200,7 @@ taskcluster:
         genericWorker:
           config:
             headlessTasks: true
+            idleTimeoutSecs: 300
 
     gw-windows-2022-staging:
       owner: taskcluster-notifications+workers@mozilla.com

--- a/generate/workers.py
+++ b/generate/workers.py
@@ -623,7 +623,6 @@ def generic_worker(wp, **cfg):
             {
                 "genericWorker": {
                     "config": {
-                        "idleTimeoutSecs": 600,
                         "wstAudience": "communitytc",
                         "wstServerURL": "https://community-websocktunnel.services.mozilla.com",
                     },


### PR DESCRIPTION
Should help make https://github.com/taskcluster/taskcluster/pull/7540 more beneficial to us.