### PR TITLE
Add rerun scope for project specific schedulers

### DIFF
--- a/config/grants.yml
+++ b/config/grants.yml
@@ -45,6 +45,9 @@
     - queue:create-task:highest:proj-<..>/*
     - queue:claim-work:proj-<..>/*
 
+    # project-specific schedulers
+    - queue:rerun-task:<..>/*
+
     # project-specific private artifacts
     - queue:get-artifact:project/<..>/*
 


### PR DESCRIPTION
Since we switched to `schedulerId: fuzzing`, I can't manually re-run fuzzing tasks anymore. I think this fixes it in a generic way.