### PR TITLE
Use GCP C3D machine type for fuzzing/ci pool

### DIFF
--- a/config/projects/fuzzing.yml
+++ b/config/projects/fuzzing.yml
@@ -62,6 +62,7 @@ fuzzing:
       cloud: gcp
       minCapacity: 0
       maxCapacity: 20
+      machineType: "zones/{zone}/machineTypes/c3d-standard-4"
     ci-arm64:
       owner: fuzzing+taskcluster@mozilla.com
       emailOnError: false


### PR DESCRIPTION
C3D gives much better performance than N2 for a small price increase.