### PR TITLE
Allow pushes to rust-code-analysis master branch to access deployment secrets

### DIFF
--- a/config/projects/relman.yml
+++ b/config/projects/relman.yml
@@ -198,7 +198,7 @@ relman:
         - generic-worker:cache:rust-code-analysis-*
       to: repo:github.com/mozilla/rust-code-analysis:*
     - grant: secrets:get:project/relman/rust-code-analysis/deploy
-      to: repo:github.com/mozilla/rust-code-analysis:tag:*
+      to: repo:github.com/mozilla/rust-code-analysis:*
 
     # rust-parsepatch
     - grant: secrets:get:project/relman/rust-parsepatch/deploy


### PR DESCRIPTION
We would like to publish the docs to gh-pages on pushes to master, and for that we need the deployment secret.