### PR TITLE
chore: bump GCP Ubuntu base image

### DIFF
--- a/imagesets/generic-worker-ubuntu-24-04-arm64/gcp_filters
+++ b/imagesets/generic-worker-ubuntu-24-04-arm64/gcp_filters
@@ -1,1 +1,1 @@
---image=ubuntu-2404-noble-arm64-v20250313 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard
+--image=ubuntu-2404-noble-arm64-v20250828 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard

--- a/imagesets/generic-worker-ubuntu-24-04/gcp_filters
+++ b/imagesets/generic-worker-ubuntu-24-04/gcp_filters
@@ -1,1 +1,1 @@
---image=ubuntu-2404-noble-amd64-v20250313 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard
+--image=ubuntu-2404-noble-amd64-v20250828 --image-project=ubuntu-os-cloud --boot-disk-size=20GB --boot-disk-type=pd-standard


### PR DESCRIPTION
Previous image was marked as deprecated.