### PR TITLE
chore(mac): add macOS files from community workers

### DIFF
--- a/misc/mac/README.md
+++ b/misc/mac/README.md
@@ -1,0 +1,29 @@
+# macOS Worker Files
+
+This directory contains configuration files and scripts extracted from static Taskcluster macOS workers. These files are preserved to avoid having to recreate them from scratch.
+
+## Files
+
+### [com.mozilla.genericworker.plist](com.mozilla.genericworker.plist)
+LaunchDaemon configuration file that automatically starts the generic worker service on macOS. It defines:
+- Service label: `com.mozilla.genericworker`
+- Executable: `/usr/local/bin/run-generic-worker.sh`
+- Logging configuration (stdout/stderr to `/var/log/genericworker/`)
+- Runs as root with network dependency
+
+### [run-generic-worker.sh](run-generic-worker.sh)
+Startup script executed by the LaunchDaemon that:
+- Cleans up files from purged users in `/private/var/folders/`
+- Changes to home directory
+- Launches the worker using `/usr/local/bin/start-worker` with config `/etc/generic-worker/runner.yml`
+
+### [runner.yml](runner.yml)
+Taskcluster worker configuration file used by `start-worker`.
+
+### [update.sh](update.sh)
+Maintenance script for updating Taskcluster worker components:
+- Fetches the latest Taskcluster version from GitHub API
+- Stops existing worker services (LaunchDaemon and LaunchAgent)
+- Downloads updated binaries: `generic-worker`, `livelog`, `start-worker`, `taskcluster-proxy`
+- Restarts the worker services
+- Includes retry logic with exponential backoff for network operations

--- a/misc/mac/com.mozilla.genericworker.plist
+++ b/misc/mac/com.mozilla.genericworker.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>com.mozilla.genericworker</string>
+        <key>Program</key>
+        <string>/usr/local/bin/run-generic-worker.sh</string>
+        <key>StandardOutPath</key>
+        <string>/var/log/genericworker/stdout.log</string>
+        <key>StandardErrorPath</key>
+        <string>/var/log/genericworker/stderr.log</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>NetworkState</key>
+        <true/>
+        <key>UserName</key>
+        <string>root</string>
+    </dict>
+</plist>

--- a/misc/mac/run-generic-worker.sh
+++ b/misc/mac/run-generic-worker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+log() {
+  echo "$(date '+%Y/%m/%d %H:%M:%S') $*"
+}
+
+log "Deleting files from purged users..."
+find /private/var/folders/ -nouser -delete
+log "Finished deleting files from purged users."
+
+log "Changing to home directory..."
+cd ~
+log "Current directory: $(pwd)"
+
+log "Starting worker..."
+/usr/local/bin/start-worker /etc/generic-worker/runner.yml
+log "Worker started"

--- a/misc/mac/runner.yml
+++ b/misc/mac/runner.yml
@@ -1,0 +1,32 @@
+provider:
+  providerType: static
+  rootURL: "https://community-tc.services.mozilla.com"
+  providerID: static
+  staticSecret: ""
+  workerPoolID: proj-taskcluster/gw-ci-macos
+  workerGroup: proj-taskcluster
+  workerID: macmini-m4-1
+  workerLocation:
+    host: macstadium
+worker:
+  implementation: generic-worker
+  path: /usr/local/bin/generic-worker
+  configPath: /etc/generic-worker/config
+workerConfig:
+  cachesDir: "/Library/Caches/generic-worker/caches"
+  cleanUpTaskDirs: true
+  disableReboots: false
+  downloadsDir: "/Library/Caches/generic-worker/downloads"
+  ed25519SigningKeyLocation: "/etc/generic-worker/ed25519_key"
+  headlessTasks: false
+  livelogExecutable: "/usr/local/bin/livelog"
+  publicIP: "207.254.33.162"
+  requiredDiskSpaceMegabytes: 20480
+  sentryProject: "generic-worker"
+  shutdownMachineOnIdle: false
+  shutdownMachineOnInternalError: false
+  taskclusterProxyExecutable: "/usr/local/bin/taskcluster-proxy"
+  taskclusterProxyPort: 8080
+  tasksDir: "/Users"
+  wstAudience: "communitytc"
+  wstServerURL: "https://community-websocktunnel.services.mozilla.com"

--- a/misc/mac/update.sh
+++ b/misc/mac/update.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+function retry {
+  set +e
+  local n=0
+  local max=20
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed" >&2
+        sleep_time=$((2 ** n))
+        echo "Sleeping $sleep_time seconds..." >&2
+        sleep $sleep_time
+        echo "Attempt $n/$max:" >&2
+      else
+        echo "Failed after $n attempts." >&2
+        exit 67
+      fi
+    }
+  done
+  set -e
+}
+
+set -eu
+set -o pipefail
+
+VERSION="$(retry curl -s https://api.github.com/repos/taskcluster/taskcluster/releases/latest | sed -n 's/.*"tag_name".*v//p' | sed 's/".*//')"
+if [ -z "${VERSION}" ]; then
+  echo "Cannot retrieve taskcluster version" >&2
+  exit 64
+fi
+
+current_user=$(scutil <<< "show State:/Users/ConsoleUser" | sed -n 's/.*Name : //p')
+uid=$(id -u "${current_user}")
+
+if [ -z "${current_user}" ] || [ -z "${uid}" ]; then
+  echo "Cannot detect current user (${current_user}) or uid (${uid})" >&2
+  exit 64
+fi
+
+cd /var/root
+launchctl unload -w /Library/LaunchDaemons/com.mozilla.genericworker.plist
+launchctl bootout "gui/${uid}" "/Users/${current_user}/Library/LaunchAgents/com.mozilla.genericworker.launchagent.plist"
+rm -f current-task-user.json next-task-user.json tasks-resolved-count.txt directory-caches.json file-caches.json
+cd /usr/local/bin
+curl -L https://github.com/taskcluster/taskcluster/releases/download/v${VERSION}/generic-worker-multiuser-darwin-arm64 > generic-worker
+curl -L https://github.com/taskcluster/taskcluster/releases/download/v${VERSION}/livelog-darwin-arm64 > livelog 
+curl -L https://github.com/taskcluster/taskcluster/releases/download/v${VERSION}/start-worker-darwin-arm64 > start-worker
+curl -L https://github.com/taskcluster/taskcluster/releases/download/v${VERSION}/taskcluster-proxy-darwin-arm64 > taskcluster-proxy
+# in case the file wasn't already present, for any reason (such as they were manually deleted)
+chmod a+x generic-worker livelog start-worker taskcluster-proxy
+launchctl bootstrap "gui/${uid}" "/Users/${current_user}/Library/LaunchAgents/com.mozilla.genericworker.launchagent.plist"
+launchctl load -w /Library/LaunchDaemons/com.mozilla.genericworker.plist


### PR DESCRIPTION
Our MacStadium workers are going away at the end of the month and I want to be sure we have the files pulled off of them so we don't have to rework all of these files.