### PR TITLE
Grant bugbug/integration secret to the bugbug hooks

### DIFF
--- a/config/projects/bugbug.yml
+++ b/config/projects/bugbug.yml
@@ -135,4 +135,5 @@ bugbug:
     - grant:
         - assume:hook-id:project-bugbug/bugbug-*
         - hooks:modify-hook:project-bugbug/bugbug-*
+        - secrets:get:project/bugbug/integration
       to: hook-id:project-bugbug/bugbug


### PR DESCRIPTION
This fixes a regression from a0da1e7f9875a1104fa2f0a4e18b9d6a24ed12c2. which removed the secret access from bugbug/build