### PR TITLE
Re-add run-task-as-current-user scopes on release pools for releases

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -356,11 +356,13 @@ taskcluster:
 
     - grant:
         - queue:create-task:highest:proj-taskcluster/release
+        - generic-worker:run-task-as-current-user:proj-taskcluster/release
         - secrets:get:project/taskcluster/release
       to: repo:github.com/taskcluster/taskcluster:tag:v*
 
     - grant:
         - queue:create-task:highest:proj-taskcluster/release
+        - generic-worker:run-task-as-current-user:proj-taskcluster/release
         - secrets:get:project/taskcluster/staging-release
       to:
         # both pre- and post-bug-1635455


### PR DESCRIPTION
51fad690ee12913ac7330b5dc4d38aeafa688f31 removed wildcard scopes on `taskcluster:*` and didn't realize that it was the only provider for the `run-task-as-current-user` scope for the release pool.