### PR TITLE
chore: point to new azure project for image building

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -160,8 +160,8 @@ generic-worker-win2022:
   workerImplementation: generic-worker
   azure:
     images:
-      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-1ed77ebf32ad46ce95e9-centralus-fuzzing
-      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-37f118e5d00544fb993f-eastus-fuzzing
+      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-1ed77ebf32ad46ce95e9-centralus-fuzzing
+      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-37f118e5d00544fb993f-eastus-fuzzing
   workerConfig:
     genericWorker:
       config:
@@ -179,7 +179,7 @@ generic-worker-win2022-staging:
   workerImplementation: generic-worker
   azure:
     images:
-      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-btxgedftadsilqkbomor-centralus
+      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-btxgedftadsilqkbomor-centralus
   workerConfig:
     genericWorker:
       config:
@@ -199,8 +199,8 @@ generic-worker-win2025-staging:
       us-east-1: ami-05fc5e0c31b199d96
   azure:
     images:
-      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-blfrhdhdcujxakvkeion-centralus
-      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-eakglbysgaxiavottjng-eastus
+      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-blfrhdhdcujxakvkeion-centralus
+      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-eakglbysgaxiavottjng-eastus
   workerConfig:
     genericWorker:
       config:
@@ -216,10 +216,10 @@ generic-worker-win2025-staging:
 generic-worker-win2022-gpu:
   azure:
     images:
-      southcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-1b7019c209fd4f5a9b64-southcentralus-fuzzing
-      westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-d9fb2fd962b649859597-westus2-fuzzing
-      eastus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-b1581c346bfc4eb69fa0-eastus2-fuzzing
-      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-799185bb01244ed4b63d-eastus-fuzzing
+      southcentralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-1b7019c209fd4f5a9b64-southcentralus-fuzzing
+      westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-d9fb2fd962b649859597-westus2-fuzzing
+      eastus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-b1581c346bfc4eb69fa0-eastus2-fuzzing
+      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-799185bb01244ed4b63d-eastus-fuzzing
   workerImplementation: generic-worker
   workerConfig:
     genericWorker:
@@ -237,7 +237,7 @@ generic-worker-win2022-gpu:
 generic-worker-win2022-gpu-staging:
   azure:
     images:
-      westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-ikwtewhhpnmyaojsljoa-westus2
+      westus2: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-ikwtewhhpnmyaojsljoa-westus2
   workerImplementation: generic-worker
   workerConfig:
     genericWorker:
@@ -256,8 +256,8 @@ generic-worker-win11-24h2-staging:
   workerImplementation: generic-worker
   azure:
     images:
-      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-stlqenyshaheamotncyg-centralus
-      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-tc-eng-images/providers/Microsoft.Compute/images/imageset-ccdkidxlucatcocbslqs-eastus
+      centralus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-stlqenyshaheamotncyg-centralus
+      eastus: /subscriptions/8a205152-b25a-417f-a676-80465535a6c9/resourceGroups/rg-packer-worker-images/providers/Microsoft.Compute/images/imageset-ccdkidxlucatcocbslqs-eastus
   workerConfig:
     genericWorker:
       config:

--- a/imagesets/README.md
+++ b/imagesets/README.md
@@ -57,9 +57,9 @@ to be present:
      * Azure only:
 
        First, run `export AZURE_IMAGE_RESOURCE_GROUP=<your Azure resource group of choice to deploy image into>`
-       (typically `rg-tc-eng-images`). Worker Manager spawns instances in resource group
+       (typically `rg-packer-worker-images`). Worker Manager spawns instances in resource group
        `rg-tc-eng-worker-manager-VMs` but typically the machine images are stored in resource group
-       `rg-tc-eng-images`.
+       `rg-packer-worker-images`.
 
      * GCP only:
 

--- a/imagesets/imageset.sh
+++ b/imagesets/imageset.sh
@@ -42,7 +42,7 @@ function all-in-parallel {
   : ${AZURE_VM_SIZES_PARALLEL_PROCESSES:=10}
 
   export GCP_PROJECT=taskcluster-imaging
-  export AZURE_IMAGE_RESOURCE_GROUP=rg-tc-eng-images
+  export AZURE_IMAGE_RESOURCE_GROUP=rg-packer-worker-images
 
   export TASKCLUSTER_CLIENT_ID='static/taskcluster/root'
   export TASKCLUSTER_ROOT_URL='https://community-tc.services.mozilla.com'


### PR DESCRIPTION
https://github.com/mozilla-platform-ops/worker-images/pull/798 moved our image building to `rg-packer-worker-images`