### PR TITLE
chore: revert docker worker image location, incorrect copy/pasta

### DIFF
--- a/config/imagesets.yml
+++ b/config/imagesets.yml
@@ -50,7 +50,7 @@ generic-worker:
 docker-worker:
   workerImplementation: docker-worker
   gcp:
-    image: projects/taskcluster-imaging/global/images/docker-worker-sfwv7ea5qm9wuoig3274
+    image: projects/community-tc-workers/global/images/docker-worker-sfwv7ea5qm9wuoig3274
   aws:
     # originally built with the `docker_community_aws` builder in monopacker
     amis:


### PR DESCRIPTION
I did a too broad find/replace in https://github.com/taskcluster/community-tc-config/pull/1002 and this caused issues in https://community-tc.services.mozilla.com/worker-manager/proj-wpt%2Fci/errors like:

>Invalid value for field 'resource.disks[0].initializeParams.sourceImage': 'projects/taskcluster-imaging/global/images/docker-worker-sfwv7ea5qm9wuoig3274'. The referenced image resource cannot be found.