### PR TITLE
Allow sealing of created task groups

### DIFF
--- a/config/projects/taskcluster.yml
+++ b/config/projects/taskcluster.yml
@@ -517,9 +517,11 @@ taskcluster:
     - grant:
         - docker-worker:cache:taskcluster-level-1-*
         - generic-worker:cache:taskcluster-level-1-*
+        - queue:cancel-task-group:taskcluster-level-1/*
         - queue:create-task:highest:built-in/succeed
         - queue:create-task:highest:proj-taskcluster/gw-ubuntu-24-04
         - queue:scheduler-id:taskcluster-level-1
+        - queue:seal-task-group:taskcluster-level-1/*
         - queue:route:checks
       to: repo:github.com/taskcluster/taskcluster:pull-request-untrusted
 
@@ -534,7 +536,9 @@ taskcluster:
         - queue:create-task:highest:proj-taskcluster/gw-windows-2022-gui
         - queue:create-task:highest:built-in/succeed
         - generic-worker:cache:taskcluster-*
+        - queue:cancel-task-group:taskcluster-level-3/*
         - queue:scheduler-id:taskcluster-level-3
+        - queue:seal-task-group:taskcluster-level-3/*
         - queue:route:checks
         - queue:route:index.taskcluster.cache.pr.docker-images.v2.*
       to:


### PR DESCRIPTION
level-1/3 was missing from the allow list, so github service couldn't seal it.

Seen in https://github.com/taskcluster/taskcluster/pull/9132#issuecomment-5584587852 